### PR TITLE
validate all inncomming auroraconfig files for unmapped paths 3 levels deep

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ filename           | name          | description
 about.json         | global        | Global configuration for all applications in an affiliation
 utv/about.json     | environment   | Environment configuration that is shared by all applications in an openshift project
 reference.json     | application   | Configuration shared by all instances of an application in all projects
-utv/refernce.json  | override      | Configuration specific to one application in one openshift project
+utv/reference.json | override      | Configuration specific to one application in one openshift project
 
 All properties in AuroraConfig can be set inn all files.
 
@@ -56,7 +56,12 @@ Below is an json with all possible values ( and some comments)
   "type" : "deploy",  //valid types are deploy,development,localTemplate, template
   "name" : "reference",
   "cluster" : "utv", //what cluster to run on. We have 6 clusters utv,test,prod and utv-relay, test-relay, prod-relay
+  "groupId": "ske.aurora.openshift.referanse", //groupId for what to deploy
+  "artifactId": "openshift-referanse-springboot-server", //artifactId for what to deploy
+  "version": "0", //version to follow
   "replicas": 3, //run application in 3 replicas
+  "envFile" : "about-template.json", ca be set in the override file, if set will use this value instead of about.json
+  "baseFile" : "new-base.json", must be set in the override file, if set will use this value instead of 
   "flags": {
     "cert": true, //generate keystore with cn=$groupId.$artifactId
     "rolling": true, //we want rolling upgrade
@@ -66,6 +71,11 @@ Below is an json with all possible values ( and some comments)
   "permissions": {
     "admin": {
       "groups": "APP_PaaS_drift APP_PaaS_utv" //what AD groups can admin this project in openshift
+      "users" : "User1 user2" //what users can admin this project in openshift
+     },
+     "view" : {
+     "groups": "APP_PaaS_drift APP_PaaS_utv" //what AD groups can view this project in openshift
+           "users" : "User1 user2" //what users can view this project in openshift
      }
   },
   "route": {
@@ -86,9 +96,7 @@ Below is an json with all possible values ( and some comments)
       "min" : "128Mi"
     }
   },
-  "groupId": "ske.aurora.openshift.referanse", //groupId for what to deploy
-  "artifactId": "openshift-referanse-springboot-server", //artifactId for what to deploy
-  "version": "0", //version to follow
+
   "prometheus": { //where is prometheus located, this is the default
     "port": "8081",
     "path": "/prometheus"
@@ -108,7 +116,17 @@ Below is an json with all possible values ( and some comments)
     }
 
   },
-  "secretVault": "test" //all secrets in the vault test are added as fields in a secret
+  "secretVault": "test" //all secrets in the vault test are added as fields in a secret,
+  "releseTo: : "prod" //when doing a deploy will not update imagestream but will share tag in docker registry. Imagestream listens to prod not version
+  "mount" : {
+      "mount-name" : {
+        "type" : "Secret", //"Secret or ConfigMap"
+        "existing" : true/false, //does the secret/configmap already exist in the cluster?
+        "path" : "/u01/volume/mount-name", //where the files are mounted
+        "content": "any content", //content to put in configmap
+        "secretVault" : "my-vault", //secret vault to use
+      }
+  }
 }
 
 ```

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigMapper.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigMapper.kt
@@ -42,6 +42,7 @@ abstract class AuroraConfigMapper(val deployCommand: DeployCommand, val auroraCo
         }
     }
 
+
     protected fun extractPermissions(): Permissions {
         val viewGroups = auroraConfigFields.extractOrNull("permissions/view/groups", { it.textValue().split(" ").toSet() })
         val viewUsers = auroraConfigFields.extractOrNull("permissions/view/users", { it.textValue().split(" ").toSet() })
@@ -65,7 +66,10 @@ abstract class AuroraConfigMapper(val deployCommand: DeployCommand, val auroraCo
     companion object {
         val baseHandlers = listOf(
                 AuroraConfigFieldHandler("schemaVersion"),
-                AuroraConfigFieldHandler("type", validator = { it.required("Type is required") }))
+                AuroraConfigFieldHandler("type", validator = { it.required("Type is required") }),
+                AuroraConfigFieldHandler("baseFile"),
+                AuroraConfigFieldHandler("envFile")
+        )
     }
 
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1.kt
@@ -11,6 +11,7 @@ import no.skatteetaten.aurora.boober.model.MountType
 import no.skatteetaten.aurora.boober.model.Route
 import no.skatteetaten.aurora.boober.service.internal.AuroraConfigException
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
+import no.skatteetaten.aurora.boober.utils.findAllPointers
 import no.skatteetaten.aurora.boober.utils.notBlank
 import no.skatteetaten.aurora.boober.utils.oneOf
 import no.skatteetaten.aurora.boober.utils.pattern
@@ -52,6 +53,15 @@ abstract class AuroraConfigMapperV1(
             AuroraConfigFieldHandler("secretVault", validator = validateSecrets()),
             AuroraConfigFieldHandler("releaseTo")
     )
+
+
+    fun getUnmappedPointers(): Map<String, List<String>> {
+        val allPaths = fieldHandlers.map { it.path }
+
+        val filePointers = applicationFiles.associateBy({ it.configName }, { it.contents.findAllPointers(3) })
+
+        return filePointers.mapValues { it.value - allPaths }.filterValues { it.isNotEmpty() }
+    }
 
     fun getRoute(): Route? {
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1Deploy.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1Deploy.kt
@@ -126,7 +126,8 @@ class AuroraConfigMapperV1Deploy(
                 serviceAccount = auroraConfigFields.extractOrNull("serviceAccount"),
                 mounts = auroraConfigFields.getMounts(mountHandlers, vaults),
                 releaseTo = auroraConfigFields.extractOrNull("releaseTo"),
-                fields = auroraConfigFields.fields
+                fields = auroraConfigFields.fields,
+                unmappedPointers = getUnmappedPointers()
         )
     }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1LocalTemplate.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1LocalTemplate.kt
@@ -51,7 +51,9 @@ class AuroraConfigMapperV1LocalTemplate(
                 parameters = auroraConfigFields.getParameters(parameterHandlers),
                 route = getRoute(),
                 mounts = auroraConfigFields.getMounts(mountHandlers, vaults),
-                fields = auroraConfigFields.fields
+                fields = auroraConfigFields.fields,
+                unmappedPointers = getUnmappedPointers()
+
         )
     }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1Template.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraConfigMapperV1Template.kt
@@ -53,7 +53,8 @@ class AuroraConfigMapperV1Template(
                 parameters = auroraConfigFields.getParameters(parameterHandlers),
                 route = getRoute(),
                 mounts = auroraConfigFields.getMounts(mountHandlers, vaults),
-                fields = auroraConfigFields.fields
+                fields = auroraConfigFields.fields,
+                unmappedPointers = getUnmappedPointers()
         )
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfig.kt
@@ -21,15 +21,22 @@ data class AuroraConfig(val auroraConfigFiles: List<AuroraConfigFile>, val affil
     }
 
 
+
     fun requiredFilesForApplication(applicationId: ApplicationId): Set<String> {
-        val baseFile = getImplementationFile(applicationId)
-                ?.contents?.get("base")?.asText()
+
+        val implementationFile = getImplementationFile(applicationId)
+        val baseFile = implementationFile
+                ?.contents?.get("baseFile")?.asText()
                 ?: "${applicationId.application}.json"
+
+        val envFile = implementationFile
+                ?.contents?.get("envFile")?.asText()
+                ?: "about.json"
 
         return setOf(
                 "about.json",
                 baseFile,
-                "${applicationId.environment}/about.json",
+                "${applicationId.environment}/$envFile",
                 "${applicationId.environment}/${applicationId.application}.json")
     }
 
@@ -67,3 +74,4 @@ data class AuroraConfig(val auroraConfigFiles: List<AuroraConfigFile>, val affil
         return this.copy(auroraConfigFiles = files)
     }
 }
+

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraDeploymentConfig.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraDeploymentConfig.kt
@@ -19,6 +19,7 @@ interface AuroraDeploymentConfig {
     val secrets: Map<String, String>?
     val config: Map<String, Map<String, String>>?
     val fields: Map<String, AuroraConfigField>
+    val unmappedPointers: Map<String, List<String>>
     val route: Route?
     val mounts: List<Mount>?
     val releaseTo: String?
@@ -88,7 +89,8 @@ data class AuroraDeploymentConfigDeploy(
         val serviceAccount: String? = null,
         override val mounts: List<Mount>? = null,
         override val fields: Map<String, AuroraConfigField>,
-        override val releaseTo: String? = null
+        override val releaseTo: String? = null,
+        override val unmappedPointers: Map<String, List<String>>
 ) : AuroraDeploymentConfig {
 
     //In use in velocity template
@@ -117,7 +119,8 @@ data class AuroraDeploymentConfigProcessLocalTemplate(
         override val route: Route? = null,
         override val mounts: List<Mount>? = null,
         override val releaseTo: String? = null,
-        val templateJson: JsonNode
+        val templateJson: JsonNode,
+        override val unmappedPointers: Map<String, List<String>>
 ) : AuroraDeploymentConfigProcess, AuroraDeploymentConfig
 
 data class AuroraDeploymentConfigProcessTemplate(
@@ -135,7 +138,8 @@ data class AuroraDeploymentConfigProcessTemplate(
         override val route: Route? = null,
         override val mounts: List<Mount>? = null,
         override val releaseTo: String? = null,
-        val template: String
+        val template: String,
+        override val unmappedPointers: Map<String, List<String>>
 
 ) : AuroraDeploymentConfigProcess, AuroraDeploymentConfig
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/internal/exceptions.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/internal/exceptions.kt
@@ -29,7 +29,7 @@ class AuroraConfigException(
         val errors: List<Error> = listOf()
 ) : ServiceException(message)
 
-data class ValidationError(val message: String, val field: AuroraConfigField? = null)
+data class ValidationError(val message: String, val field: AuroraConfigField? = null, val fileName: String? = null)
 
 class AuroraVersioningException(message: String, val errors: List<VersioningError>) : ServiceException(message)
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -9,8 +9,7 @@ fun JsonNode.findAllPointers(maxLevel: Int): List<String> {
     fun inner(root: String, node: ObjectNode): List<String> {
 
         if (root.split("/").size > maxLevel) {
-
-            return emptyList()
+            return listOf(root)
         }
         val ret = mutableListOf<String>()
         for ((key, child) in node.fields()) {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -3,6 +3,34 @@ package no.skatteetaten.aurora.boober.utils
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 
+
+fun JsonNode.findAllPointers(maxLevel: Int): List<String> {
+
+    fun inner(root: String, node: ObjectNode): List<String> {
+
+        if (root.split("/").size > maxLevel) {
+
+            return emptyList()
+        }
+        val ret = mutableListOf<String>()
+        for ((key, child) in node.fields()) {
+            val newKey = "$root/$key"
+            if (child is ObjectNode) {
+                ret += inner(newKey, child)
+            } else {
+                ret += newKey
+            }
+        }
+        return ret
+    }
+
+    if (this is ObjectNode) {
+        return inner("", this)
+    } else {
+        return listOf()
+    }
+}
+
 fun JsonNode.updateField(source: JsonNode, root: String, field: String, required: Boolean = false) {
     val sourceField = source.at("$root/$field")
 
@@ -32,6 +60,7 @@ fun JsonNode?.startsWith(pattern: String, message: String): Exception? {
 
     return null
 }
+
 fun JsonNode?.pattern(pattern: String, message: String): Exception? {
     if (this == null) {
         return IllegalArgumentException(message)

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/AuroraConfigServiceTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/AuroraConfigServiceTest.groovy
@@ -99,7 +99,7 @@ class AuroraConfigServiceTest extends Specification {
 
   }
 
-  def "should findUnmappedPaths in json file and return too long maps"() {
+  def "should findUnmappedPaths in json file and ignore too long maps"() {
     given:
       JsonNode json = mapper.convertValue([
           config: ["latest.properties": ["BAZ": "ads"]],
@@ -111,7 +111,9 @@ class AuroraConfigServiceTest extends Specification {
       def res = AuroraConfigHelperKt.findAllPointers(json, 3)
 
     then:
-      res == ["/config/latest.properties/BAZ", "/baz/asd"]
+      res == ["/config/latest.properties/BAZ",
+              "/baz/asd",
+              "/mount/foo/content"]
 
   }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/service/AuroraConfigHelper.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/service/AuroraConfigHelper.kt
@@ -5,6 +5,7 @@ import no.skatteetaten.aurora.boober.Configuration
 import no.skatteetaten.aurora.boober.model.ApplicationId
 import no.skatteetaten.aurora.boober.model.AuroraConfig
 import no.skatteetaten.aurora.boober.model.AuroraConfigFile
+import no.skatteetaten.aurora.boober.utils.findAllPointers
 import java.io.File
 
 class AuroraConfigHelper
@@ -24,6 +25,7 @@ fun getAuroraConfigSamples(): AuroraConfig {
     return AuroraConfig(nodes.map { AuroraConfigFile(it.key, it.value!!, false) }, "aos")
 }
 
+fun findAllPointers(node: JsonNode, maxLevel: Int) = node.findAllPointers(maxLevel)
 
 @JvmOverloads
 fun createAuroraConfig(aid: ApplicationId, affiliation: String = "aos", additionalFile: String? = null): AuroraConfig {

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/service/TestData.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/service/TestData.kt
@@ -1,7 +1,16 @@
 package no.skatteetaten.aurora.boober.service
 
 import com.fasterxml.jackson.databind.JsonNode
-import no.skatteetaten.aurora.boober.model.*
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigDeploy
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigFlags
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigProcessLocalTemplate
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigResource
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigResources
+import no.skatteetaten.aurora.boober.model.Database
+import no.skatteetaten.aurora.boober.model.Permission
+import no.skatteetaten.aurora.boober.model.Permissions
+import no.skatteetaten.aurora.boober.model.Route
+import no.skatteetaten.aurora.boober.model.TemplateType
 
 val auroraDcDevelopment = AuroraDeploymentConfigDeploy(
         schemaVersion = "v1",
@@ -33,7 +42,8 @@ val auroraDcDevelopment = AuroraDeploymentConfigDeploy(
         secrets = emptyMap(),
         extraTags = "",
         route = Route(),
-        fields = emptyMap()
+        fields = emptyMap(),
+        unmappedPointers = emptyMap()
 )
 
 
@@ -61,4 +71,5 @@ fun generateProccessADC(template: JsonNode) =
                 secrets = emptyMap(),
                 config = emptyMap(),
                 route = Route(),
-                fields = emptyMap())
+                fields = emptyMap(),
+                unmappedPointers = emptyMap())

--- a/src/test/resources/samples/config/booberdev/aos-complex.json
+++ b/src/test/resources/samples/config/booberdev/aos-complex.json
@@ -1,3 +1,3 @@
 {
-  "base": "aos-simple.json"
+  "baseFile": "aos-simple.json"
 }

--- a/src/test/resources/samples/config/customenv/about-template.json
+++ b/src/test/resources/samples/config/customenv/about-template.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": "v1",
+  "type": "deploy",
+  "cluster": "utv"
+}

--- a/src/test/resources/samples/config/customenv/about.json
+++ b/src/test/resources/samples/config/customenv/about.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": "v1",
+  "type": "development",
+  "cluster": "utv"
+}

--- a/src/test/resources/samples/config/customenv/aos-simple.json
+++ b/src/test/resources/samples/config/customenv/aos-simple.json
@@ -1,0 +1,3 @@
+{
+  "envFile": "about-template.json"
+}


### PR DESCRIPTION
add support for specifying alternate env file. Because some project have template specific properties in the about file.