### PR TITLE
all mounts have adc.name prefixed in their name. Could we solve this …

### DIFF
--- a/src/main/resources/templates/mount.json.vm
+++ b/src/main/resources/templates/mount.json.vm
@@ -2,7 +2,7 @@
   "kind": "${mount.type.name()}",
   "apiVersion": "v1",
   "metadata": {
-    "name": "${mount.volumeName}",
+    "name": "${adc.name}-${mount.volumeName}",
     "labels": {
       "app": "${adc.name}",
       "updatedBy": "${username}",

--- a/src/test/resources/samples/result/booberdev/sprocket/sprocketconfig.json
+++ b/src/test/resources/samples/result/booberdev/sprocket/sprocketconfig.json
@@ -2,7 +2,7 @@
   "kind": "ConfigMap",
   "apiVersion": "v1",
   "metadata": {
-    "name": "sprocket-config",
+    "name": "sprocket-sprocket-config",
     "labels": {
       "app": "sprocket",
       "updatedBy": "hero",

--- a/src/test/resources/samples/result/booberdev/tvinn/tvinnconfig.json
+++ b/src/test/resources/samples/result/booberdev/tvinn/tvinnconfig.json
@@ -2,7 +2,7 @@
   "kind": "ConfigMap",
   "apiVersion": "v1",
   "metadata": {
-    "name": "tvinn-config",
+    "name": "tvinn-tvinn-config",
     "labels": {
       "app": "tvinn",
       "updatedBy": "hero",

--- a/src/test/resources/samples/result/secretmount/aos-simple/secret.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/secret.json
@@ -2,7 +2,7 @@
   "kind": "Secret",
   "apiVersion": "v1",
   "metadata": {
-    "name": "secret-mount",
+    "name": "aos-simple-secret-mount",
     "labels": {
       "app": "aos-simple",
       "updatedBy": "hero",


### PR DESCRIPTION
…with ensuring that it starts with it so that it is not doubled up?