### PR TITLE
Bugfix/aos 2096 fikse regresjonsfeil med retry

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftRequestHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftRequestHandler.kt
@@ -3,36 +3,96 @@ package no.skatteetaten.aurora.boober.service.openshift
 import com.fasterxml.jackson.databind.JsonNode
 import no.skatteetaten.aurora.boober.service.OpenShiftException
 import no.skatteetaten.aurora.boober.utils.logger
+import org.slf4j.Logger
 import org.springframework.http.RequestEntity
 import org.springframework.http.ResponseEntity
-import org.springframework.retry.annotation.Backoff
-import org.springframework.retry.annotation.Retryable
+import org.springframework.retry.RetryCallback
+import org.springframework.retry.RetryContext
+import org.springframework.retry.backoff.FixedBackOffPolicy
+import org.springframework.retry.listener.RetryListenerSupport
+import org.springframework.retry.policy.SimpleRetryPolicy
+import org.springframework.retry.support.RetryTemplate
 import org.springframework.stereotype.Component
 import org.springframework.web.client.RestClientException
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.RestTemplate
 
+
 @Component
 class OpenShiftRequestHandler(val restTemplate: RestTemplate) {
 
-    val logger by logger()
+    companion object {
+        val REQUEST_ENTITY = "requestEntity"
+    }
 
-    @Retryable(value = OpenShiftException::class, maxAttempts = 3, backoff = Backoff(delay = 500))
+    final val logger by logger()
+
+    val retryTemplate = retryTemplate(logger)
+
     fun <T> exchange(requestEntity: RequestEntity<T>): ResponseEntity<JsonNode> {
 
-        val createResponse: ResponseEntity<JsonNode> = try {
-            logger.info("${requestEntity.method} resource at ${requestEntity.url}")
-            restTemplate.exchange(requestEntity, JsonNode::class.java)
-        } catch (e: RestClientResponseException) {
-            val messages = "Request failed will be retried. url=${requestEntity.url}, method=${requestEntity.method}, message=${e.message}, code=${e.rawStatusCode}, statusText=${e.statusText}"
-            logger.debug(messages)
-            throw OpenShiftException(messages, e)
-        } catch (e: RestClientException) {
-            val messages = "Request failed will be retried url=${requestEntity.url}, method=${requestEntity.method}, message=${e.message}"
-            logger.debug(messages)
-            throw OpenShiftException(messages, e)
+        val responseEntity = retryTemplate.execute<ResponseEntity<JsonNode>, RestClientException> {
+            it.setAttribute(REQUEST_ENTITY, requestEntity)
+            try {
+                restTemplate.exchange(requestEntity, JsonNode::class.java)
+            } catch (e: Exception) {
+                throw OpenShiftException("An error occurred while communicating with OpenShift", e)
+            }
         }
-        logger.trace("Body={}", createResponse.body)
-        return createResponse
+        logger.trace("Body={}", responseEntity.body)
+        return responseEntity
+    }
+
+    private final fun retryTemplate(logger: Logger): RetryTemplate {
+
+        val template = RetryTemplate().apply {
+            setRetryPolicy(SimpleRetryPolicy(3))
+            setBackOffPolicy(FixedBackOffPolicy().apply {
+                backOffPeriod = 500
+            })
+        }
+
+        template.registerListener(RetryLogger(logger))
+        return template
+    }
+}
+
+class RetryLogger(val logger: Logger) : RetryListenerSupport() {
+
+    /**
+     * Logs whether the request was successful or not
+     */
+    override fun <T : Any?, E : Throwable?> close(context: RetryContext?, callback: RetryCallback<T, E>?, throwable: Throwable?) {
+
+        val requestEntity: RequestEntity<*> = context?.getAttribute(OpenShiftRequestHandler.REQUEST_ENTITY) as RequestEntity<*>
+        if (context.getAttribute(RetryContext.EXHAUSTED)?.let { it as Boolean } == true) {
+            logger.error("Request failed. Giving up. url=${requestEntity.url}, method=${requestEntity.method}")
+        } else {
+            logger.debug("Requested url=${requestEntity.url}, method=${requestEntity.method}")
+        }
+        super.close(context, callback, throwable)
+    }
+
+    /**
+     * Logs information about the request and the number of attempts when an error occurs.
+     */
+    override fun <T : Any?, E : Throwable?> onError(context: RetryContext?, callback: RetryCallback<T, E>?, e: Throwable?) {
+
+        val requestEntity: RequestEntity<*> = context?.getAttribute(OpenShiftRequestHandler.REQUEST_ENTITY) as RequestEntity<*>
+        val cause = e?.cause
+        val params = mutableMapOf(
+                "attempt" to context.retryCount,
+                "url" to requestEntity.url,
+                "method" to requestEntity.method,
+                "message" to cause?.message
+        )
+        if (cause is RestClientResponseException) {
+            params.put("code", cause.rawStatusCode)
+            params.put("statusText", cause.statusText)
+        }
+
+        val message = StringBuilder("Request failed. ")
+        params.map { "${it.key}=${it.value}" }.joinTo(message, ", ")
+        logger.warn(message.toString())
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftRequestHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftRequestHandler.kt
@@ -32,7 +32,7 @@ class OpenShiftRequestHandler(val restTemplate: RestTemplate) {
             logger.debug(messages)
             throw OpenShiftException(messages, e)
         }
-        logger.trace("Body=${createResponse.body}")
+        logger.trace("Body={}", createResponse.body)
         return createResponse
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftRequestHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftRequestHandler.kt
@@ -2,8 +2,7 @@ package no.skatteetaten.aurora.boober.service.openshift
 
 import com.fasterxml.jackson.databind.JsonNode
 import no.skatteetaten.aurora.boober.service.OpenShiftException
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import no.skatteetaten.aurora.boober.utils.logger
 import org.springframework.http.RequestEntity
 import org.springframework.http.ResponseEntity
 import org.springframework.retry.annotation.Backoff
@@ -16,7 +15,7 @@ import org.springframework.web.client.RestTemplate
 @Component
 class OpenShiftRequestHandler(val restTemplate: RestTemplate) {
 
-    val logger: Logger = LoggerFactory.getLogger(OpenShiftRequestHandler::class.java)
+    val logger by logger()
 
     @Retryable(value = OpenShiftException::class, maxAttempts = 3, backoff = Backoff(delay = 500))
     fun <T> exchange(requestEntity: RequestEntity<T>): ResponseEntity<JsonNode> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/slfj4.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/slfj4.kt
@@ -1,0 +1,19 @@
+package no.skatteetaten.aurora.boober.utils
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import kotlin.reflect.full.companionObject
+
+
+public fun <R : Any> R.logger(): Lazy<Logger> {
+    return lazy { LoggerFactory.getLogger(unwrapCompanionClass(this.javaClass).name) }
+}
+
+// unwrap companion class to enclosing class given a Java Class
+public fun <T : Any> unwrapCompanionClass(ofClass: Class<T>): Class<*> {
+    return if (ofClass.enclosingClass != null && ofClass.enclosingClass.kotlin.companionObject?.java == ofClass) {
+        ofClass.enclosingClass
+    } else {
+        ofClass
+    }
+}

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftRequestHandlerTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftRequestHandlerTest.groovy
@@ -39,8 +39,7 @@ class OpenShiftRequestHandlerTest extends AbstractAuroraDeploymentSpecSpringTest
       osClusterMock.expect(requestTo(resourceUrl)).andRespond(withSuccess(resource, APPLICATION_JSON))
 
     when:
-      ResponseEntity<JsonNode> entity = requestHandler.
-          exchangeWithRetry(new RequestEntity<Object>(GET, new URI(resourceUrl)))
+      ResponseEntity<JsonNode> entity = requestHandler.exchange(new RequestEntity<Object>(GET, new URI(resourceUrl)))
 
     then:
       JsonOutput.prettyPrint(entity.body.toString()) == JsonOutput.prettyPrint(resource)
@@ -53,7 +52,7 @@ class OpenShiftRequestHandlerTest extends AbstractAuroraDeploymentSpecSpringTest
       3.times { osClusterMock.expect(requestTo(resourceUrl)).andRespond(withBadRequest()) }
 
     when:
-      requestHandler.exchangeWithRetry(new RequestEntity<Object>(GET, new URI(resourceUrl)))
+      requestHandler.exchange(new RequestEntity<Object>(GET, new URI(resourceUrl)))
 
     then:
       thrown(OpenShiftException)

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftRequestHandlerTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftRequestHandlerTest.groovy
@@ -6,6 +6,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.RequestEntity
@@ -14,6 +15,8 @@ import org.springframework.test.web.client.MockRestServiceServer
 
 import com.fasterxml.jackson.databind.JsonNode
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
 import groovy.json.JsonOutput
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftRequestHandler
 
@@ -30,6 +33,11 @@ class OpenShiftRequestHandlerTest extends AbstractAuroraDeploymentSpecSpringTest
 
   @Value('${openshift.url}/oapi/v1/namespaces/aos/deploymentconfigs/webleveranse')
   String resourceUrl
+
+  def setup() {
+    Logger root = (Logger)LoggerFactory.getLogger("no.skatteetaten")
+    root.setLevel(Level.DEBUG)
+  }
 
   def "Succeeds even if the request fails a couple of times"() {
 


### PR DESCRIPTION
@bjartek En rafaktorisering du gjorde i forbindelse med ytelsesoptimaliseringen har i praksis disablet retrymekanismen. Denne pren fikser dette. Det er imidlertid ikke gjort noen ytterligere tester om dette får negativ effekt på ytelse. Vi må teste ordentlig før utrulling.