### PR TITLE
Bugfix/aos 2126 retry ved 404 gir darlig ytelse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.1.51'
+  ext.kotlin_version = '1.1.60'
   ext.springBootVersion = '1.5.8.RELEASE'
   ext.auroraStartersVersion = '3.3.0'
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftClient.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftClient.kt
@@ -104,7 +104,7 @@ class OpenShiftClient(
             return OpenshiftCommand(OperationType.NOOP, payload = json)
         }
 
-        val existingResource = if (projectExist) userClient.get(kind, namespace, name) else null
+        val existingResource = if (projectExist) userClient.get(kind, namespace, name, false) else null
         if (existingResource == null) {
             return OpenshiftCommand(OperationType.CREATE, payload = json)
         }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftResourceClient.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftResourceClient.kt
@@ -23,18 +23,17 @@ open class OpenShiftResourceClient(@Value("\${openshift.url}") val baseUrl: Stri
         return openShiftRequestHandler.exchange(RequestEntity<JsonNode>(payload, headers, HttpMethod.PUT, URI(urls.update)))
     }
 
-    open fun get(kind: String, namespace: String, name: String): ResponseEntity<JsonNode>? {
+    open fun get(kind: String, namespace: String, name: String, retry: Boolean = true): ResponseEntity<JsonNode>? {
 
         val urls: OpenShiftApiUrls = OpenShiftApiUrls.createOpenShiftApiUrls(baseUrl, kind, namespace, name)
         val url = urls.get ?: return null
 
-        return get(url)
+        return get(url, retry = retry)
     }
 
-
-    open fun get(url: String, headers: HttpHeaders = getAuthorizationHeaders()): ResponseEntity<JsonNode>? {
+    open fun get(url: String, headers: HttpHeaders = getAuthorizationHeaders(), retry: Boolean = true): ResponseEntity<JsonNode>? {
         try {
-            return openShiftRequestHandler.exchange(RequestEntity<Any>(headers, HttpMethod.GET, URI(url)))
+            return openShiftRequestHandler.exchange(RequestEntity<Any>(headers, HttpMethod.GET, URI(url)), retry)
         } catch (e: OpenShiftException) {
             if (e.cause is HttpClientErrorException && e.cause.statusCode == HttpStatus.NOT_FOUND) {
                 return null

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftClientApplyTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftClientApplyTest.groovy
@@ -79,7 +79,7 @@ class OpenShiftClientApplyTest extends Specification {
       def projectRequest = mapper.readTree(prFile)
 
       serviceAccountClient.get(_, _) >> new ResponseEntity<JsonNode>(HttpStatus.OK)
-      userClient.get("project", "foobar", "foobar") >> {
+      userClient.get("project", "foobar", "foobar", false) >> {
         throw new OpenShiftException("Does not exist", new HttpClientErrorException(HttpStatus.SERVICE_UNAVAILABLE))
       }
 
@@ -99,7 +99,7 @@ class OpenShiftClientApplyTest extends Specification {
 
     when:
 
-      userClient.get("projectrequest", "foobar", "foobar") >> null
+      userClient.get("projectrequest", "foobar", "foobar", false) >> null
 
       userClient.post("projectrequest", "foobar", "foobar", projectRequest) >>
           new ResponseEntity(projectRequest, HttpStatus.OK)
@@ -121,7 +121,7 @@ class OpenShiftClientApplyTest extends Specification {
 
       serviceAccountClient.get(_, _) >> new ResponseEntity<JsonNode>(HttpStatus.OK)
 
-      userClient.get(type, "foobar", "referanse") >>
+      userClient.get(type, "foobar", "referanse", false) >>
           new ResponseEntity(oldResource, HttpStatus.OK)
 
       userClient.put(type, "foobar", "referanse", _) >>

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftClientCommandTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftClientCommandTest.groovy
@@ -87,7 +87,7 @@ class OpenShiftClientCommandTest extends Specification {
         def apiUrl = OpenShiftApiUrls.getCollectionPathForResource(baseUrl, kind, namespace)
         def url = "$apiUrl?$queryString" as String
 
-        userClient.get(url, _) >> ResponseEntity.ok(it.value)
+        userClient.get(url, _, true) >> ResponseEntity.ok(it.value)
       }
 
     when:

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftObjectGeneratorConfigMapTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftObjectGeneratorConfigMapTest.groovy
@@ -74,7 +74,6 @@ class OpenShiftObjectGeneratorConfigMapTest extends AbstractAuroraDeploymentSpec
       def jsonMounts = objectGenerator.generateMount(deploymentSpec, "deploy-id")
 
     then:
-      deploymentSpec.fields.findAll { it.key.contains("config") }.each { println it }
       jsonMounts.size() == 1
       JsonNode mount = jsonMounts.first()
 

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftRequestHandlerTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftRequestHandlerTest.groovy
@@ -47,7 +47,7 @@ class OpenShiftRequestHandlerTest extends AbstractAuroraDeploymentSpecSpringTest
       osClusterMock.expect(requestTo(resourceUrl)).andRespond(withSuccess(resource, APPLICATION_JSON))
 
     when:
-      ResponseEntity<JsonNode> entity = requestHandler.exchange(new RequestEntity<Object>(GET, new URI(resourceUrl)))
+      ResponseEntity<JsonNode> entity = requestHandler.exchange(new RequestEntity<Object>(GET, new URI(resourceUrl)), true)
 
     then:
       JsonOutput.prettyPrint(entity.body.toString()) == JsonOutput.prettyPrint(resource)
@@ -60,7 +60,21 @@ class OpenShiftRequestHandlerTest extends AbstractAuroraDeploymentSpecSpringTest
       3.times { osClusterMock.expect(requestTo(resourceUrl)).andRespond(withBadRequest()) }
 
     when:
-      requestHandler.exchange(new RequestEntity<Object>(GET, new URI(resourceUrl)))
+      requestHandler.exchange(new RequestEntity<Object>(GET, new URI(resourceUrl)), true)
+
+    then:
+      thrown(OpenShiftException)
+  }
+
+  def "Fails immediately when retry is disabled"() {
+
+    given:
+      def resourceUrl = "$openShiftUrl/oapi/v1/namespaces/aos/deploymentconfigs/webleveranse"
+      1.times { osClusterMock.expect(requestTo(resourceUrl)).andRespond(withBadRequest()) }
+      0 * osClusterMock._
+
+    when:
+      requestHandler.exchange(new RequestEntity<Object>(GET, new URI(resourceUrl)), false)
 
     then:
       thrown(OpenShiftException)


### PR DESCRIPTION
Retrying is tricky...

We need to disable retry on some get requests to avoid a performance hit when resources does not exist during deploy. We should, perhaps, however, always enable retry on underlying network errors. That could/should be considered an improvement.