### PR TITLE
added configuration to remove uri tag for restTemplate. (#119)

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/AuroraRestTemplateTagsProvider.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/AuroraRestTemplateTagsProvider.kt
@@ -1,0 +1,23 @@
+package no.skatteetaten.aurora.boober
+
+import java.util.Arrays
+
+import org.springframework.http.HttpRequest
+import org.springframework.http.client.ClientHttpResponse
+import org.springframework.stereotype.Component
+
+import io.micrometer.core.instrument.Tag
+import io.micrometer.spring.web.client.RestTemplateExchangeTags
+import io.micrometer.spring.web.client.RestTemplateExchangeTagsProvider
+
+@Component
+class AuroraRestTemplateTagsProvider : RestTemplateExchangeTagsProvider {
+
+    override fun getTags(urlTemplate: String?, request: HttpRequest,
+                         response: ClientHttpResponse): Iterable<Tag> {
+        return Arrays.asList(RestTemplateExchangeTags.method(request),
+                RestTemplateExchangeTags.status(response),
+                RestTemplateExchangeTags.clientName(request))
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,10 +15,11 @@ spring:
     caffeine:
       spec: maximumSize=2000,expireAfterAccess=300s
     cache-names: groups
-    metrics:
-        prometheus:
-            timerPercentilesMax: "PT5S"
-            timerPercentilesMin: "PT0.1S"
+  metrics:
+    prometheus:
+      timerPercentilesMin: "PT0.1S"
+      timerPercentilesMax: "PT5S"
+
 boober:
     git:
        checkoutPath: "/tmp/boober"


### PR DESCRIPTION
* added configuration to remove uri tag for restTemplate.

* fixed error in tags provider, and fixed configuration of metrics.

http :8081/prometheus | grep client                                                                                                                      14:44:35
# HELP http_client_requests_duration_seconds Timer of RestTemplate operation
# TYPE http_client_requests_duration_seconds histogram
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.111848106",} 2.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.134217727",} 2.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.156587348",} 2.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.178956969",} 2.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.20132659",} 2.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.223696211",} 3.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.246065832",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.268435456",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.357913941",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.447392426",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.536870911",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.626349396",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.715827881",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.805306366",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.894784851",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="0.984263336",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="1.073741824",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="1.431655765",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="1.789569706",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="2.147483647",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="2.505397588",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="2.863311529",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="3.22122547",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="3.579139411",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="3.937053352",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="4.294967296",} 4.0
http_client_requests_duration_seconds_bucket{clientName="qa-master.paas.skead.no",method="GET",status="200",le="+Inf",} 4.0
http_client_requests_duration_seconds_count{clientName="qa-master.paas.skead.no",method="GET",status="200",} 4.0
http_client_requests_duration_seconds_sum{clientName="qa-master.paas.skead.no",method="GET",status="200",} 0.44952183700000004