### PR TITLE
response can be null

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/AuroraRestTemplateTagsProvider.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/AuroraRestTemplateTagsProvider.kt
@@ -14,7 +14,7 @@ import io.micrometer.spring.web.client.RestTemplateExchangeTagsProvider
 class AuroraRestTemplateTagsProvider : RestTemplateExchangeTagsProvider {
 
     override fun getTags(urlTemplate: String?, request: HttpRequest,
-                         response: ClientHttpResponse): Iterable<Tag> {
+                         response: ClientHttpResponse?): Iterable<Tag> {
         return Arrays.asList(RestTemplateExchangeTags.method(request),
                 RestTemplateExchangeTags.status(response),
                 RestTemplateExchangeTags.clientName(request))


### PR DESCRIPTION
 Request failed. attempt=1, url=https://utv-master.paas.skead.no:8443/oapi/v1/projects/folk-x-morten, method=GET, message=Parameter specified as non-null is null: method no.skatteetaten.aurora.boober.AuroraRestTemplateTagsProvider.getTags, parameter response