### PR TITLE
Feature/support array config

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
@@ -123,7 +123,7 @@ class AuroraConfigFields(val fields: Map<String, AuroraConfigField>) {
     inline fun <reified T> extract(name: String): T = fields[name]!!.value()
 
     /**
-     * Extracts a config field declared either as a CSV (ie. "value1, value2") or as a JSON array
+     * Extracts a config field declared either as a delimited string (ie. "value1, value2") or as a JSON array
      * (ie. ["value1", "value2"]) as a String list.
      */
     fun extractDelimitedStringOrArrayAsStringList(name: String, delimiter: String = ","): List<String> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
@@ -122,12 +122,24 @@ class AuroraConfigFields(val fields: Map<String, AuroraConfigField>) {
 
     inline fun <reified T> extract(name: String): T = fields[name]!!.value()
 
+    /**
+     * Extracts a config field declared either as a CSV (ie. "value1, value2") or as a JSON array
+     * (ie. ["value1", "value2"]) as a String list.
+     */
+    fun extractDelimitedStringOrArrayAsStringList(name: String, delimiter: String = ","): List<String> {
+        val field = fields[name]!!
+        val valueNode = field.value
+        return when {
+            valueNode.isTextual -> valueNode.textValue().split(delimiter).toList()
+            valueNode.isArray -> (field.value() as List<Any?>).map { it?.toString() } // Convert any non-string values in the array to string
+            else -> emptyList()
+        }.filter { !it.isNullOrBlank() }
+                .mapNotNull { it?.trim() }
+    }
+
     inline fun <reified T> extractOrNull(name: String): T? = fields[name]!!.getNullableValue()
 
-    inline fun <reified T> extractIfExistsOrNull(name: String) : T? = fields[name]?.let { it.getNullableValue() }
-
-
-
+    inline fun <reified T> extractIfExistsOrNull(name: String): T? = fields[name]?.getNullableValue()
 
     companion object {
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeployMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeployMapperV1.kt
@@ -2,18 +2,7 @@ package no.skatteetaten.aurora.boober.mapper.v1
 
 import no.skatteetaten.aurora.boober.mapper.AuroraConfigFieldHandler
 import no.skatteetaten.aurora.boober.mapper.AuroraConfigFields
-import no.skatteetaten.aurora.boober.model.ApplicationId
-import no.skatteetaten.aurora.boober.model.ApplicationPlatform
-import no.skatteetaten.aurora.boober.model.AuroraConfigFile
-import no.skatteetaten.aurora.boober.model.AuroraDeploy
-import no.skatteetaten.aurora.boober.model.AuroraDeployStrategy
-import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigFlags
-import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigResource
-import no.skatteetaten.aurora.boober.model.AuroraDeploymentConfigResources
-import no.skatteetaten.aurora.boober.model.Database
-import no.skatteetaten.aurora.boober.model.HttpEndpoint
-import no.skatteetaten.aurora.boober.model.Probe
-import no.skatteetaten.aurora.boober.model.Webseal
+import no.skatteetaten.aurora.boober.model.*
 import no.skatteetaten.aurora.boober.utils.ensureStartWith
 import no.skatteetaten.aurora.boober.utils.length
 import no.skatteetaten.aurora.boober.utils.notBlank
@@ -156,9 +145,12 @@ class AuroraDeployMapperV1(val applicationId: ApplicationId, val applicationFile
             return null
         }
 
+        val roles = auroraConfigFields.extractDelimitedStringOrArrayAsStringList("$name/roles", ",")
+                .takeIf { it.isNotEmpty() }
+                ?.joinToString(",")
         return Webseal(
                 auroraConfigFields.extractOrNull("$name/host"),
-                auroraConfigFields.extractDelimitedStringOrArrayAsStringList("$name/roles", ",").joinToString(",")
+                roles
         )
 
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeployMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeployMapperV1.kt
@@ -158,7 +158,7 @@ class AuroraDeployMapperV1(val applicationId: ApplicationId, val applicationFile
 
         return Webseal(
                 auroraConfigFields.extractOrNull("$name/host"),
-                auroraConfigFields.extractOrNull("$name/roles")
+                auroraConfigFields.extractDelimitedStringOrArrayAsStringList("$name/roles", ",").joinToString(",")
         )
 
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecMapperV1.kt
@@ -20,8 +20,10 @@ class AuroraDeploymentSpecMapperV1(val applicationId: ApplicationId) {
             AuroraConfigFieldHandler("permissions/view"),
             AuroraConfigFieldHandler("permissions/adminServiceAccount"),
             // Max length of OpenShift project names is 63 characters. Project name = affiliation + "-" + envName.
-            AuroraConfigFieldHandler("envName", validator = { it.pattern("^[a-z0-9\\-]{0,52}$",
-                    "Environment must consist of lower case alphanumeric characters or '-'. It must be no longer than 52 characters.") },
+            AuroraConfigFieldHandler("envName", validator = {
+                it.pattern("^[a-z0-9\\-]{0,52}$",
+                        "Environment must consist of lower case alphanumeric characters or '-'. It must be no longer than 52 characters.")
+            },
                     defaultSource = "folderName",
                     defaultValue = applicationId.environment
             ),
@@ -148,20 +150,17 @@ class AuroraDeploymentSpecMapperV1(val applicationId: ApplicationId) {
         return configFields + fields
     }
 
-    private fun extractPermissions(auroraConfigFields: AuroraConfigFields): Permissions {
-        val view = auroraConfigFields.extractOrNull<String?>("permissions/view")?.let {
-            it.split(" ").toSet()
-        }?.let {
-            Permission(it)
-        }
+    private fun extractPermissions(configFields: AuroraConfigFields): Permissions {
 
+        val viewGroups = configFields.extractDelimitedStringOrArrayAsStringList("permissions/view").toSet()
+        val adminGroups = configFields.extractDelimitedStringOrArrayAsStringList("permissions/admin", " ")
         //if sa present add to admin users.
-        val sa = auroraConfigFields.extractOrNull<String?>("permissions/adminServiceAccount")?.let { it.split(" ").toSet() } ?: emptySet()
-        val permission = Permissions(
-                admin = Permission(
-                        auroraConfigFields.extract<String>("permissions/admin").let { it.split(" ").filter { !it.isBlank() }.toSet() }, sa),
-                view = view)
-        return permission
+        val adminUsers = configFields.extractDelimitedStringOrArrayAsStringList("permissions/adminServiceAccount", " ").toSet()
+
+        val adminPermission = Permission(adminGroups.toSet(), adminUsers)
+        val viewPermission = viewGroups.takeIf { !it.isEmpty() }?.let { Permission(it) }
+
+        return Permissions(admin = adminPermission, view = viewPermission)
     }
 }
 

--- a/src/test/groovy/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpecBuilderTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpecBuilderTest.groovy
@@ -215,4 +215,21 @@ class AuroraDeploymentSpecBuilderTest extends AbstractAuroraDeploymentSpecTest {
     where:
       adminPermissions << ["APP_PaaS_utv APP_PaaS_drift", ["APP_PaaS_utv", "APP_PaaS_drift"]]
   }
+
+  def "Webseal roles supports both comma separated string and array"() {
+    given:
+      modify(auroraConfigJson, "utv/aos-simple.json") {
+        put("webseal", [ "roles": roleConfig ])
+      }
+
+    when:
+      AuroraDeploymentSpec deploymentSpec = createDeploymentSpec(auroraConfigJson, DEFAULT_AID)
+
+    then:
+      def roles = deploymentSpec.deploy.webseal.roles
+      roles == "role1,role2,3"
+
+    where:
+      roleConfig << ["role1,role2,3", "role1, role2, 3", ["role1", "role2", 3]]
+  }
 }

--- a/src/test/groovy/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpecBuilderTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpecBuilderTest.groovy
@@ -198,4 +198,21 @@ class AuroraDeploymentSpecBuilderTest extends AbstractAuroraDeploymentSpecTest {
       '''{ "secretVault": {"name": "test", "keys": []} }'''                 | "test"      | []
       '''{ "secretVault": {"name": "test", "keys": ["test1", "test2"]} }''' | "test"      | ["test1", "test2"]
   }
+
+  def "Permissions supports both space separated string and array"() {
+    given:
+      modify(auroraConfigJson, "about.json", {
+        put("permissions", ["admin": adminPermissions])
+      })
+
+    when:
+      AuroraDeploymentSpec deploymentSpec = createDeploymentSpec(auroraConfigJson, DEFAULT_AID)
+
+    then:
+      def adminGroups = deploymentSpec.environment.permissions.admin.groups
+      adminGroups == ["APP_PaaS_utv", "APP_PaaS_drift"] as Set
+
+    where:
+      adminPermissions << ["APP_PaaS_utv APP_PaaS_drift", ["APP_PaaS_utv", "APP_PaaS_drift"]]
+  }
 }


### PR DESCRIPTION
Based on the implementation of secretVaultKeys supporting array as config, we decided to optionally support arrays for the other places in the config where we today only support delimited strings. 