### PR TITLE
AOS-2418 - Do not parse and then write back content in boober

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/controller/internal/Payloads.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/controller/internal/Payloads.kt
@@ -3,11 +3,10 @@ package no.skatteetaten.aurora.boober.controller.internal
 import no.skatteetaten.aurora.boober.model.ApplicationId
 import no.skatteetaten.aurora.boober.model.AuroraConfigFile
 
-typealias JsonDataFiles = Map<String, String>
 
 
 data class ApplyPayload(val applicationIds: List<ApplicationId>,
-                        val overrides: JsonDataFiles = mapOf(),
+                        val overrides: Map<String, String> = mapOf(),
                         val deploy: Boolean = true
 ) {
     fun overridesToAuroraConfigFiles(): List<AuroraConfigFile> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/controller/internal/Payloads.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/controller/internal/Payloads.kt
@@ -1,10 +1,9 @@
 package no.skatteetaten.aurora.boober.controller.internal
 
-import com.fasterxml.jackson.databind.JsonNode
 import no.skatteetaten.aurora.boober.model.ApplicationId
 import no.skatteetaten.aurora.boober.model.AuroraConfigFile
 
-typealias JsonDataFiles = Map<String, JsonNode>
+typealias JsonDataFiles = Map<String, String>
 
 
 data class ApplyPayload(val applicationIds: List<ApplicationId>,

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/controller/v1/AuroraConfigControllerV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/controller/v1/AuroraConfigControllerV1.kt
@@ -22,13 +22,13 @@ data class AuroraConfigResource(
         val files: List<AuroraConfigFileResource> = listOf()
 ) {
     fun toAuroraConfig(affiliation: String): AuroraConfig {
-        val auroraConfigFiles = files.map { AuroraConfigFile(it.name, jacksonYamlObjectMapper().readTree(it.contents)) }
+        val auroraConfigFiles = files.map { AuroraConfigFile(it.name,  it.contents) }
         return AuroraConfig(auroraConfigFiles, affiliation)
     }
 
     companion object {
         fun fromAuroraConfig(auroraConfig: AuroraConfig): AuroraConfigResource {
-            return AuroraConfigResource(auroraConfig.affiliation, auroraConfig.auroraConfigFiles.map { AuroraConfigFileResource(it.name, it.contents.toString()) })
+            return AuroraConfigResource(auroraConfig.affiliation, auroraConfig.auroraConfigFiles.map { AuroraConfigFileResource(it.name, it.contents) })
         }
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/controller/v1/DeployControllerV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/controller/v1/DeployControllerV1.kt
@@ -4,8 +4,6 @@ import no.skatteetaten.aurora.boober.controller.internal.ApplyPayload
 import no.skatteetaten.aurora.boober.controller.internal.Response
 import no.skatteetaten.aurora.boober.service.DeployService
 import no.skatteetaten.aurora.boober.service.AuroraDeployResult
-import no.skatteetaten.aurora.boober.service.DeployHistory
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 
 data class AuroraConfigField(val handler: AuroraConfigFieldHandler, val source: AuroraConfigFile? = null) {
     val value: JsonNode
-        get() = source?.contents?.at(handler.path) ?: MissingNode.getInstance()
+        get() = source?.asJsonNode?.at(handler.path) ?: MissingNode.getInstance()
     val valueOrDefault: JsonNode?
         get() =
             value.let {
@@ -42,7 +42,7 @@ inline fun <reified T> AuroraConfigField.value(): T {
         return this.handler.defaultValue as T
     }
 
-    val value = this.source.contents.at(this.handler.path)
+    val value = this.source.asJsonNode.at(this.handler.path)
 
     return jacksonObjectMapper().convertValue(value, T::class.java)
 
@@ -112,7 +112,7 @@ class AuroraConfigFields(val fields: Map<String, AuroraConfigField>) {
         if (field.source == null) {
             return field.handler.defaultValue is Boolean
         }
-        val value = field.source.contents.at(field.handler.path)
+        val value = field.source.asJsonNode.at(field.handler.path)
 
         if (value.isBoolean) {
             return true
@@ -138,7 +138,7 @@ class AuroraConfigFields(val fields: Map<String, AuroraConfigField>) {
             val fields: Map<String, AuroraConfigField> = handlers.map { handler ->
                 val matches = files.reversed().mapNotNull {
                     logger.trace("Check if  ${handler.path} exist in file  ${it.contents}")
-                    val value = it.contents.at(handler.path)
+                    val value = it.asJsonNode.at(handler.path)
 
                     if (!value.isMissingNode) {
                         logger.trace("Match $value i fil ${it.configName}")

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecConfigFieldValidator.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecConfigFieldValidator.kt
@@ -74,7 +74,7 @@ class AuroraDeploymentSpecConfigFieldValidator(val applicationId: ApplicationId,
     private fun getUnmappedPointers(): Map<String, List<String>> {
         val allPaths = fieldHandlers.map { it.path }
 
-        val filePointers = applicationFiles.associateBy({ it.configName }, { it.contents.findAllPointers(3) })
+        val filePointers = applicationFiles.associateBy({ it.configName }, { it.asJsonNode.findAllPointers(3) })
 
         return filePointers.mapValues { it.value - allPaths }.filterValues { it.isNotEmpty() }
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraLocalTemplateMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraLocalTemplateMapperV1.kt
@@ -41,7 +41,7 @@ class AuroraLocalTemplateMapperV1(val applicationFiles: List<AuroraConfigFile>, 
 
     private fun extractTemplateJson(auroraConfigFields: AuroraConfigFields): JsonNode {
         val templateFile = auroraConfigFields.extract<String>("templateFile").let { fileName ->
-            auroraConfig.auroraConfigFiles.find { it.name == fileName }?.contents
+            auroraConfig.auroraConfigFiles.find { it.name == fileName }?.asJsonNode
         }
         return templateFile ?: throw IllegalArgumentException("templateFile is required")
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraRouteMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraRouteMapperV1.kt
@@ -57,7 +57,7 @@ class AuroraRouteMapperV1(val applicationId: ApplicationId, val applicationFiles
     fun findRouteAnnotaionHandlers(prefix: String): List<AuroraConfigFieldHandler> {
 
         return applicationFiles.flatMap { ac ->
-            ac.contents.at("/$prefix/annotations")?.fieldNames()?.asSequence()?.toList() ?: emptyList()
+            ac.asJsonNode.at("/$prefix/annotations")?.fieldNames()?.asSequence()?.toList() ?: emptyList()
         }.toSet().map { key ->
             AuroraConfigFieldHandler("$prefix/annotations/$key")
         }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/mappingFunctions.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/mappingFunctions.kt
@@ -5,8 +5,8 @@ import no.skatteetaten.aurora.boober.model.AuroraConfigFile
 
 fun List<AuroraConfigFile>.findSubKeys(name: String): Set<String> {
     return this.flatMap {
-        if (it.contents.has(name)) {
-            it.contents[name].fieldNames().asSequence().toList()
+        if (it.asJsonNode.has(name)) {
+            it.asJsonNode[name].fieldNames().asSequence().toList()
         } else {
             emptyList()
         }
@@ -21,7 +21,7 @@ fun List<AuroraConfigFile>.findConfigFieldHandlers(): List<AuroraConfigFieldHand
     val configKeys: Map<String, Set<String>> = keysStartingWithConfig.map { configFileName ->
         //find all unique keys in a configFile
         val keys = this.flatMap { ac ->
-            ac.contents.at("/$name/$configFileName")?.fieldNames()?.asSequence()?.toList() ?: emptyList()
+            ac.asJsonNode.at("/$name/$configFileName")?.fieldNames()?.asSequence()?.toList() ?: emptyList()
         }.toSet()
 
         configFileName to keys

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigFile.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigFile.kt
@@ -2,14 +2,19 @@ package no.skatteetaten.aurora.boober.model
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import no.skatteetaten.aurora.boober.utils.jacksonYamlObjectMapper
 import org.springframework.util.DigestUtils
 
-data class AuroraConfigFile(val name: String, val contents: JsonNode, val override: Boolean = false) {
+data class AuroraConfigFile(val name: String, val contents: String, val override: Boolean = false) {
     val configName
         get() = if (override) "$name.override" else name
 
     val version
         get() = DigestUtils.md5DigestAsHex(jacksonObjectMapper().writeValueAsString(contents).toByteArray())
+
+    val asJsonNode: JsonNode by lazy {
+        jacksonYamlObjectMapper().readValue(contents, JsonNode::class.java)
+    }
 }
 
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpec.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpec.kt
@@ -90,7 +90,7 @@ data class AuroraBuild(
 
 data class AuroraDeploy(
         val applicationFile: String,
-        val overrideFiles: Map<String, JsonNode>,
+        val overrideFiles: Map<String, String>,
         val releaseTo: String?,
         val flags: AuroraDeploymentConfigFlags,
         val resources: AuroraDeploymentConfigResources,

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/errors.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/errors.kt
@@ -29,7 +29,7 @@ class ConfigFieldErrorDetail(type: ErrorType, message: String, val field: Aurora
         }
 
         fun invalid(filename: String, path: String): ConfigFieldErrorDetail {
-            val acf = AuroraConfigField(AuroraConfigFieldHandler(path.substring(1)), AuroraConfigFile(filename, TextNode("")))
+            val acf = AuroraConfigField(AuroraConfigFieldHandler(path.substring(1)), AuroraConfigFile(filename, ""))
             return ConfigFieldErrorDetail(ErrorType.INVALID, "$path is not a valid config field pointer", acf)
         }
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraConfigService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraConfigService.kt
@@ -81,14 +81,9 @@ class AuroraConfigService(@TargetDomain(AURORA_CONFIG) val gitService: GitServic
             FileUtils.deleteQuietly(outputFile)
         }
         auroraConfig.auroraConfigFiles.forEach {
-            val writeMapper = if(it.configName.endsWith(".yaml")) {
-               yamlMapper
-            } else mapper
-
-            val prettyContent = writeMapper.writerWithDefaultPrettyPrinter().writeValueAsString(it.contents)
             val outputFile = File(getAuroraConfigFolder(auroraConfig.affiliation), it.name)
             FileUtils.forceMkdirParent(outputFile)
-            outputFile.writeText(prettyContent)
+            outputFile.writeText(it.contents)
         }
 
         gitService.commitAndPushChanges(repo)
@@ -99,9 +94,8 @@ class AuroraConfigService(@TargetDomain(AURORA_CONFIG) val gitService: GitServic
     @JvmOverloads
     fun updateAuroraConfigFile(name: String, fileName: String, contents: String, previousVersion: String? = null): AuroraConfig {
 
-        val jsonContents = yamlMapper.readValue(contents, JsonNode::class.java)
         val oldAuroraConfig = findAuroraConfig(name)
-        val (newFile, auroraConfig) = oldAuroraConfig.updateFile(fileName, jsonContents, previousVersion)
+        val (newFile, auroraConfig) = oldAuroraConfig.updateFile(fileName, contents , previousVersion)
 
         return saveFile(newFile, auroraConfig)
     }
@@ -133,14 +127,9 @@ class AuroraConfigService(@TargetDomain(AURORA_CONFIG) val gitService: GitServic
         val checkoutDir = getAuroraConfigFolder(auroraConfig.affiliation)
         watch.start("write file")
 
-        val writeMapper = if(newFile.configName.endsWith(".yaml")) {
-            yamlMapper
-        } else mapper
-
-        val prettyContent = writeMapper.writerWithDefaultPrettyPrinter().writeValueAsString(newFile.contents)
         val outputFile = File(checkoutDir, newFile.name)
         FileUtils.forceMkdirParent(outputFile)
-        outputFile.writeText(prettyContent)
+        outputFile.writeText(newFile.contents)
         watch.stop()
 
         watch.start("git")

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/internal/DeploymentConfigGenerator.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/internal/DeploymentConfigGenerator.kt
@@ -57,8 +57,9 @@ class DeploymentConfigGenerator(
                 "boober.skatteetaten.no/applicationFile" to deploy.applicationFile,
                 "console.skatteetaten.no/alarm" to deploy.flags.alarm.toString()
         )
-        //TODO: I am not sure if this takeIf ever works. Since we write all the override files as a json string
-        val overrides = StringEscapeUtils.escapeJavaScript(mapper.writeValueAsString(deploy.overrideFiles)).takeIf { it != "{}" }?.let {
+        val files = deploy.overrideFiles.mapValues{ mapper.readValue(it.value, JsonNode::class.java)}
+        val content = mapper.writeValueAsString(files)
+        val overrides = StringEscapeUtils.escapeJavaScript(content).takeIf { it != "{}" }?.let {
             "boober.skatteetaten.no/overrides" to it
         }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/internal/DeploymentConfigGenerator.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/internal/DeploymentConfigGenerator.kt
@@ -57,6 +57,7 @@ class DeploymentConfigGenerator(
                 "boober.skatteetaten.no/applicationFile" to deploy.applicationFile,
                 "console.skatteetaten.no/alarm" to deploy.flags.alarm.toString()
         )
+        //TODO: I am not sure if this takeIf ever works. Since we write all the override files as a json string
         val overrides = StringEscapeUtils.escapeJavaScript(mapper.writeValueAsString(deploy.overrideFiles)).takeIf { it != "{}" }?.let {
             "boober.skatteetaten.no/overrides" to it
         }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -1,10 +1,12 @@
 package no.skatteetaten.aurora.boober.utils
 
+import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.JsonNodeType
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 
@@ -147,4 +149,6 @@ fun JsonNode.toPrimitiveType(): Any? {
     }
 }
 
-fun jacksonYamlObjectMapper(): ObjectMapper = ObjectMapper(YAMLFactory()).registerKotlinModule()
+fun jacksonYamlObjectMapper(): ObjectMapper = ObjectMapper(YAMLFactory().enable(JsonParser.Feature.ALLOW_COMMENTS)).registerKotlinModule()
+
+fun jsonMapper(): ObjectMapper = jacksonObjectMapper().enable(JsonParser.Feature.ALLOW_COMMENTS)

--- a/src/test/groovy/no/skatteetaten/aurora/boober/controller/AuroraConfigControllerTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/controller/AuroraConfigControllerTest.groovy
@@ -82,7 +82,7 @@ class AuroraConfigControllerTest extends AbstractAuroraConfigTest {
 
     given:
       def fileToUpdate = DEFAULT_ABOUT
-      def auroraConfigFile = new AuroraConfigFile("about.json", new ObjectMapper().readValue(fileToUpdate, JsonNode),
+      def auroraConfigFile = new AuroraConfigFile("about.json", fileToUpdate,
           false)
       def eTag = "THIS_IS_NOT_THE_EXPECTED_ETAG"
       def payload = [content: modify(fileToUpdate, { route: true })]

--- a/src/test/groovy/no/skatteetaten/aurora/boober/model/AbstractAuroraConfigTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/model/AbstractAuroraConfigTest.groovy
@@ -99,9 +99,8 @@ abstract class AbstractAuroraConfigTest extends AbstractSpec {
 
     static AuroraConfig createAuroraConfig(Map<String, String> auroraConfigJson) {
 
-        def yamlMapperMapper = jacksonYamlObjectMapper()
         def auroraConfigFiles = auroraConfigJson.collect { name, contents ->
-          new AuroraConfigFile(name, yamlMapperMapper.readValue(contents, JsonNode), false)
+          new AuroraConfigFile(name, contents, false)
         }
         def auroraConfig = new AuroraConfig(auroraConfigFiles, "aos")
         auroraConfig

--- a/src/test/groovy/no/skatteetaten/aurora/boober/model/AuroraConfigTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/model/AuroraConfigTest.groovy
@@ -26,7 +26,7 @@ class AuroraConfigTest extends AbstractAuroraConfigTest {
   def "Should update file"() {
     given:
       def auroraConfig = AuroraConfigHelperKt.createAuroraConfig(aid)
-      def updates = mapper.convertValue(["version": "4"], JsonNode.class)
+      def updates = '''{ "version": "4"}'''
 
     when:
 
@@ -35,7 +35,7 @@ class AuroraConfigTest extends AbstractAuroraConfigTest {
     then:
       def version = updatedAuroraConfig.getAuroraConfigFiles().stream()
           .filter({ it.configName == "booberdev/console.json" })
-          .map({ it.contents.get("version").asText() })
+          .map({ it.asJsonNode.get("version").asText() })
           .findFirst()
 
       version.isPresent()
@@ -45,7 +45,8 @@ class AuroraConfigTest extends AbstractAuroraConfigTest {
   def "Should create file when updating nonexisting file"() {
     given:
       def auroraConfig = AuroraConfigHelperKt.createAuroraConfig(aid)
-      def updates = mapper.convertValue(["version": "4"], JsonNode.class)
+
+      def updates = '''{ "version": "4"}'''
       def fileName = "boobertest/console.json"
 
     expect:
@@ -57,7 +58,7 @@ class AuroraConfigTest extends AbstractAuroraConfigTest {
     then:
       def version = updatedAuroraConfig.getAuroraConfigFiles().stream()
           .filter({ it.configName == fileName })
-          .map({ it.contents.get("version").asText() })
+          .map({ it.asJsonNode.get("version").asText() })
           .findFirst()
 
       version.isPresent()
@@ -134,7 +135,7 @@ class AuroraConfigTest extends AbstractAuroraConfigTest {
     then:
       filesForApplication.size() == 4
       def applicationFile = filesForApplication.find { it.name == 'booberdev/aos-complex.json' }
-      String baseFile = applicationFile.contents.get("baseFile").textValue()
+      String baseFile = applicationFile.asJsonNode.get("baseFile").textValue()
       filesForApplication.any { it.name == baseFile }
   }
 
@@ -157,14 +158,14 @@ class AuroraConfigTest extends AbstractAuroraConfigTest {
 
     then:
       def patchedFile = patchedAuroraConfig.auroraConfigFiles.find { it.name == filename }
-      patchedFile.contents.at("/version").textValue() == "3"
+      patchedFile.asJsonNode.at("/version").textValue() == "3"
   }
 
   List<AuroraConfigFile> createMockFiles(String... files) {
-    files.collect { new AuroraConfigFile(it, mapper.readValue("{}", JsonNode.class), false) }
+    files.collect { new AuroraConfigFile(it, "{}", false) }
   }
 
   def overrideFile(String fileName) {
-    new AuroraConfigFile(fileName, mapper.readValue("{}", JsonNode.class), true)
+    new AuroraConfigFile(fileName, "{}", true)
   }
 }

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftObjectGeneratorTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftObjectGeneratorTest.groovy
@@ -24,7 +24,7 @@ class OpenShiftObjectGeneratorTest extends AbstractOpenShiftObjectGeneratorTest 
   OpenShiftObjectGenerator objectGenerator = createObjectGenerator("hero")
 
   @Shared
-  def file = new ObjectMapper().convertValue([version: "1.0.4"], JsonNode.class)
+  def file = '''{ "version": "1.0.4"}'''
 
   @Shared
   def booberDevAosSimpleOverrides = [new AuroraConfigFile("booberdev/aos-simple.json", file, true)]

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigHelper.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigHelper.kt
@@ -24,7 +24,6 @@ fun getAuroraConfigSamples(): AuroraConfig {
     return AuroraConfig(nodes.map { AuroraConfigFile(it.key, it.value, false) }, "aos")
 }
 
-fun findAllPointers(node: JsonNode, maxLevel: Int) = node.findAllPointers(maxLevel)
 
 @JvmOverloads
 fun createAuroraConfig(aid: ApplicationId, affiliation: String = "aos", additionalFile: String? = null): AuroraConfig {
@@ -36,7 +35,7 @@ fun createAuroraConfig(aid: ApplicationId, affiliation: String = "aos", addition
 @JvmOverloads
 fun getSampleFiles(aid: ApplicationId, additionalFile: String? = null): Map<String, String> {
 
-    return collectFilesToMapOfJsonNode(
+    return collectFiles(
             "about.json",
             "${aid.application}.json",
             "${aid.environment}/about.json",
@@ -52,22 +51,6 @@ fun getResultFiles(aid: ApplicationId): Map<String, JsonNode?> {
     return getFiles(baseFolder)
 }
 
-fun getDeployResultFiles(aid: ApplicationId): Map<String, JsonNode?> {
-    val baseFolder = File(AuroraConfigHelper::class.java
-            .getResource("/samples/deployresult/${aid.environment}/${aid.application}").file)
-
-    return getFiles(baseFolder, aid.application)
-}
-
-fun getRendererResultFiles(aid: ApplicationId): Map<String, JsonNode?> {
-    val baseFolder = File(AuroraConfigHelper::class.java
-            .getResource("/samples/rendererresult/${aid.environment}").file)
-
-    return baseFolder.listFiles().toHashSet().map {
-        val json = convertFileToJsonNode(it)
-        it.name to json
-    }.toMap()
-}
 
 private fun getFiles(baseFolder: File, name: String = ""): Map<String, JsonNode?> {
     return baseFolder.listFiles().toHashSet().map {
@@ -83,7 +66,7 @@ private fun getFiles(baseFolder: File, name: String = ""): Map<String, JsonNode?
     }.toMap()
 }
 
-private fun collectFilesToMapOfJsonNode(vararg fileNames: String): Map<String, String> {
+private fun collectFiles(vararg fileNames: String): Map<String, String> {
 
     return fileNames.filter { !it.isBlank() }.map { it to File(folder, it).readText(Charset.defaultCharset()) }.toMap()
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigHelper.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigHelper.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import no.skatteetaten.aurora.boober.Configuration
 import no.skatteetaten.aurora.boober.utils.findAllPointers
 import java.io.File
+import java.nio.charset.Charset
 
 class AuroraConfigHelper
 
@@ -17,10 +18,10 @@ fun getAuroraConfigSamples(): AuroraConfig {
             .associate { it.relativeTo(folder).path to it }
 
     val nodes = files.map {
-        it.key to convertFileToJsonNode(it.value)
+        it.key to it.value.readText(Charset.defaultCharset())
     }.toMap()
 
-    return AuroraConfig(nodes.map { AuroraConfigFile(it.key, it.value!!, false) }, "aos")
+    return AuroraConfig(nodes.map { AuroraConfigFile(it.key, it.value, false) }, "aos")
 }
 
 fun findAllPointers(node: JsonNode, maxLevel: Int) = node.findAllPointers(maxLevel)
@@ -29,11 +30,11 @@ fun findAllPointers(node: JsonNode, maxLevel: Int) = node.findAllPointers(maxLev
 fun createAuroraConfig(aid: ApplicationId, affiliation: String = "aos", additionalFile: String? = null): AuroraConfig {
     val files = getSampleFiles(aid, additionalFile)
 
-    return AuroraConfig(files.map { AuroraConfigFile(it.key, it.value!!, false) }, affiliation)
+    return AuroraConfig(files.map { AuroraConfigFile(it.key, it.value, false) }, affiliation)
 }
 
 @JvmOverloads
-fun getSampleFiles(aid: ApplicationId, additionalFile: String? = null): Map<String, JsonNode?> {
+fun getSampleFiles(aid: ApplicationId, additionalFile: String? = null): Map<String, String> {
 
     return collectFilesToMapOfJsonNode(
             "about.json",
@@ -82,9 +83,9 @@ private fun getFiles(baseFolder: File, name: String = ""): Map<String, JsonNode?
     }.toMap()
 }
 
-private fun collectFilesToMapOfJsonNode(vararg fileNames: String): Map<String, JsonNode?> {
+private fun collectFilesToMapOfJsonNode(vararg fileNames: String): Map<String, String> {
 
-    return fileNames.filter { !it.isBlank() }.map { it to convertFileToJsonNode(File(folder, it)) }.toMap()
+    return fileNames.filter { !it.isBlank() }.map { it to File(folder, it).readText(Charset.defaultCharset()) }.toMap()
 }
 
 private fun convertFileToJsonNode(file: File): JsonNode? {


### PR DESCRIPTION
AuroraConfigFile now represents the content as a String and will lazily parse as Json if needed. When writing the content out we always use the raw content value and do not go through jackson at all. 

NB! Will patch auroraconfig file work with comments?
I am not sure it will. We will need to test it out manually I think. 