### PR TITLE
Feature/aos 2288 test

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/DeployService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/DeployService.kt
@@ -5,10 +5,7 @@ import no.skatteetaten.aurora.boober.model.ApplicationId
 import no.skatteetaten.aurora.boober.model.AuroraConfigFile
 import no.skatteetaten.aurora.boober.model.AuroraDeployEnvironment
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
-import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
-import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResponse
-import no.skatteetaten.aurora.boober.service.openshift.OpenshiftCommand
-import no.skatteetaten.aurora.boober.service.openshift.OperationType
+import no.skatteetaten.aurora.boober.service.openshift.*
 import no.skatteetaten.aurora.boober.service.resourceprovisioning.ExternalResourceProvisioner
 import no.skatteetaten.aurora.boober.service.resourceprovisioning.ProvisioningResult
 import no.skatteetaten.aurora.boober.utils.addIfNotNull
@@ -18,6 +15,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.util.*
+import kotlin.collections.ArrayList
 
 @Service
 //TODO:Split up. Service is to large
@@ -133,6 +131,7 @@ class DeployService(
 
     fun deployFromSpec(deploymentSpec: AuroraDeploymentSpec, shouldDeploy: Boolean, namespaceCreated: Boolean): AuroraDeployResult {
 
+        val openShiftStatus = OpenShiftStatus(ArrayList<OpenShiftResponse>())
         val deployId = UUID.randomUUID().toString().substring(0, 7)
         if (deploymentSpec.cluster != cluster) {
             return AuroraDeployResult(auroraDeploymentSpec = deploymentSpec, ignored = true, reason = "Not valid in this cluster.")
@@ -142,12 +141,12 @@ class DeployService(
         val provisioningResult = resourceProvisioner.provisionResources(deploymentSpec)
 
         logger.debug("Apply objects")
-        val openShiftResponses: List<OpenShiftResponse> = applyOpenShiftApplicationObjects(
-                deployId, deploymentSpec, provisioningResult, namespaceCreated)
+        openShiftStatus.addResponses(applyOpenShiftApplicationObjects(
+                deployId, deploymentSpec, provisioningResult, namespaceCreated))
 
         logger.debug("done applying objects")
-        val success = openShiftResponses.all { it.success }
-        val result = AuroraDeployResult(deploymentSpec, deployId, openShiftResponses, success)
+        val success = openShiftStatus.openShiftResponses.all { it.success }
+        val result = AuroraDeployResult(deploymentSpec, deployId, openShiftStatus.openShiftResponses, success)
         if (!shouldDeploy) {
             return result.copy(reason = "Deploy explicitly turned of.")
         }
@@ -165,16 +164,15 @@ class DeployService(
             val cmd = TagCommand("$dockerGroup/${it.artifactId}", it.version, it.releaseTo!!, dockerRegistry)
             dockerService.tag(cmd)
         }
-        val redeployResult = redeployService.triggerRedeploy(deploymentSpec, openShiftResponses)
+        val redeployResult = redeployService.triggerRedeploy(deploymentSpec, openShiftStatus)
 
         if (!redeployResult.success) {
-            return result.copy(openShiftResponses = openShiftResponses.addIfNotNull(redeployResult.openShiftResponses),
-                    tagResponse = tagResult, success = false, reason = redeployResult.message)
+            return result.copy(openShiftResponses = openShiftStatus.openShiftResponses, tagResponse = tagResult, success = false, reason = redeployResult.message)
         }
 
         val totalSuccess = listOf(success, tagResult?.success, redeployResult.success).filterNotNull().all { it }
 
-        return result.copy(openShiftResponses = openShiftResponses.addIfNotNull(redeployResult.openShiftResponses), tagResponse = tagResult,
+        return result.copy(openShiftResponses = openShiftStatus.openShiftResponses, tagResponse = tagResult,
                 success = totalSuccess, reason = "Deployment success.")
     }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/RedeployService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/RedeployService.kt
@@ -1,132 +1,74 @@
 package no.skatteetaten.aurora.boober.service
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.node.ArrayNode
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.model.TemplateType
-import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
-import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResponse
-import no.skatteetaten.aurora.boober.utils.openshiftKind
-import no.skatteetaten.aurora.boober.utils.openshiftName
+import no.skatteetaten.aurora.boober.service.openshift.*
 import org.springframework.stereotype.Service
 
 @Service
 class RedeployService(val openShiftClient: OpenShiftClient, val openShiftObjectGenerator: OpenShiftObjectGenerator) {
 
-    data class ImageInformation(val lastTriggeredImage: String, val imageStreamName: String, val imageStreamTag: String)
-
-    data class VerificationResult(val success: Boolean = true, val message: String? = null)
-
     data class RedeployResult @JvmOverloads constructor(
-            val openShiftResponses: List<OpenShiftResponse> = listOf(),
             val success: Boolean = true,
             val message: String? = null) {
 
         companion object {
-            fun fromOpenShiftResponses(openShiftResponses: List<OpenShiftResponse>): RedeployResult {
-                val success = openShiftResponses?.all { it.success }
+            fun fromOpenShiftStatus(openShiftStatus: OpenShiftStatus): RedeployResult {
+                val success = openShiftStatus.openShiftResponses.all { it.success }
                 val message = if (success) "Redeploy succeeded" else "Redeploy failed"
-                return RedeployResult(openShiftResponses = openShiftResponses, success = success, message = message)
+                return RedeployResult(success = success, message = message)
             }
         }
     }
 
-    fun triggerRedeploy(deploymentSpec: AuroraDeploymentSpec, openShiftResponses: List<OpenShiftResponse>): RedeployResult {
+    fun triggerRedeploy(deploymentSpec: AuroraDeploymentSpec, status: OpenShiftStatus): RedeployResult {
 
         val namespace = deploymentSpec.environment.namespace
-
-        val redeployResourceFromSpec = generateRedeployResourceFromSpec(deploymentSpec, openShiftResponses) ?: return RedeployResult()
+        val redeployResourceFromSpec = generateRedeployResourceFromSpec(deploymentSpec, status) ?: return RedeployResult()
         val command = openShiftClient.createOpenShiftCommand(namespace, redeployResourceFromSpec)
 
         try {
-            val response = openShiftClient.performOpenShiftCommand(namespace, command)
-
-            verifyResponse(response).takeUnless { it.success }?.let {
-                return RedeployResult(success = false, message = it?.message, openShiftResponses = listOf(response))
+            status.addResponse(openShiftClient.performOpenShiftCommand(namespace, command))
+            status.verifyImageStreamImport().takeUnless { it.success }?.let {
+                return RedeployResult(success = false, message = it.message)
             }
 
-            if (response.command.payload.openshiftKind != "imagestreamimport" || didImportImage(response, openShiftResponses)) {
-                return RedeployResult.fromOpenShiftResponses(listOf(response))
+            if (status.didImportImage()) {
+                return RedeployResult()
             }
             val cmd = openShiftClient.createOpenShiftCommand(namespace,
                     openShiftObjectGenerator.generateDeploymentRequest(deploymentSpec.name))
 
             try {
-                return RedeployResult.fromOpenShiftResponses(listOf(response, openShiftClient.performOpenShiftCommand(namespace, cmd)))
-            } catch (e: OpenShiftException) {
-                return RedeployResult.fromOpenShiftResponses(listOf(response, OpenShiftResponse.fromOpenShiftException(e, command)))
+                status.addResponse(openShiftClient.performOpenShiftCommand(namespace, cmd))
+                return RedeployResult.fromOpenShiftStatus(status)
+              } catch (e: OpenShiftException) {
+                status.addResponse(OpenShiftResponse.fromOpenShiftException(e, command))
+                return RedeployResult.fromOpenShiftStatus(status)
             }
         } catch (e: OpenShiftException) {
-            return RedeployResult.fromOpenShiftResponses(listOf(OpenShiftResponse.fromOpenShiftException(e, command)))
+            status.addResponse(OpenShiftResponse.fromOpenShiftException(e, command))
+            return RedeployResult.fromOpenShiftStatus(status)
         }
     }
 
-    protected fun verifyResponse(response: OpenShiftResponse): VerificationResult {
-        val body = response.responseBody ?: return VerificationResult(success = false, message = "No response found")
-        val images = body.at("/status/images") as? ArrayNode
-
-        images?.find { it["status"]["status"].textValue()?.toLowerCase().equals("failure") }?.let {
-            return VerificationResult(success = false, message = it["status"]["message"]?.textValue())
-        }
-
-        return VerificationResult(success = true)
-    }
-
-    protected fun didImportImage(response: OpenShiftResponse, openShiftResponses: List<OpenShiftResponse>): Boolean {
-
-        val body = response.responseBody ?: return true
-        val info = findImageInformation(openShiftResponses) ?: return true
-        if (info.lastTriggeredImage.isBlank()) {
-            return false
-        }
-
-        val tags = body.at("/status/import/status/tags") as ArrayNode
-        tags.find { it["tag"].asText() == info.imageStreamTag }?.let {
-            val allTags = it["items"] as ArrayNode
-            val tag = allTags.first()
-            return tag["dockerImageReference"].asText() != info.lastTriggeredImage
-        }
-
-        return true
-    }
-
-    protected fun findImageInformation(openShiftResponses: List<OpenShiftResponse>): ImageInformation? {
-        val dc = openShiftResponses.find { it.responseBody?.openshiftKind == "deploymentconfig" }?.responseBody ?: return null
-
-        val triggers = dc.at("/spec/triggers") as ArrayNode
-        return triggers.find { it["type"].asText().toLowerCase() == "imagechange" }?.let {
-            val (isName, tag) = it.at("/imageChangeParams/from/name").asText().split(':')
-            val lastTriggeredImage = it.at("/imageChangeParams/lastTriggeredImage")?.asText() ?: ""
-            ImageInformation(lastTriggeredImage, isName, tag)
-        }
-    }
-
-    protected fun generateRedeployResourceFromSpec(deploymentSpec: AuroraDeploymentSpec, openShiftResponses: List<OpenShiftResponse>): JsonNode? {
-        return generateRedeployResource(deploymentSpec.type, deploymentSpec.name, openShiftResponses)
+    protected fun generateRedeployResourceFromSpec(deploymentSpec: AuroraDeploymentSpec, status: OpenShiftStatus): JsonNode? {
+        return generateRedeployResource(deploymentSpec.type, deploymentSpec.name, status)
 
     }
 
-    protected fun generateRedeployResource(type: TemplateType, name: String, openShiftResponses: List<OpenShiftResponse>): JsonNode? {
+    protected fun generateRedeployResource(type: TemplateType, name: String, status: OpenShiftStatus): JsonNode? {
         if (type == TemplateType.build || type == TemplateType.development) {
             return null
         }
 
-        val imageStream = openShiftResponses.find { it.responseBody?.openshiftKind == "imagestream" }
-        val deployment = openShiftResponses.find { it.responseBody?.openshiftKind == "deploymentconfig" }
-        if (imageStream == null && deployment != null) {
+        if (!status.hasResponse("imagestream") && status.hasResponse("deploymentconfig")) {
             return openShiftObjectGenerator.generateDeploymentRequest(name)
         }
 
-        findImageInformation(openShiftResponses)?.let { imageInformation ->
-            imageStream?.responseBody?.takeIf { it.openshiftName == imageInformation.imageStreamName }?.let {
-                val tags = it.at("/spec/tags") as ArrayNode
-                tags.find { it["name"].asText() == imageInformation.imageStreamTag }?.let {
-                    val dockerImageName = it.at("/from/name").asText()
-                    return openShiftObjectGenerator.generateImageStreamImport(imageInformation.imageStreamName, dockerImageName)
-                }
-            }
-        }
+        val streamInfo = status.findImageStreamInformation()
 
-        return null
+        return openShiftObjectGenerator.generateImageStreamImport(streamInfo!!.name, streamInfo.dockerImageName)
     }
 }

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/RedeployServiceTriggerRedeployTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/RedeployServiceTriggerRedeployTest.groovy
@@ -1,0 +1,61 @@
+package no.skatteetaten.aurora.boober.service
+
+import com.google.common.collect.ArrayTable
+import no.skatteetaten.aurora.boober.model.AuroraDeployEnvironment
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
+import no.skatteetaten.aurora.boober.model.Permission
+import no.skatteetaten.aurora.boober.model.Permissions
+import no.skatteetaten.aurora.boober.model.TemplateType
+import no.skatteetaten.aurora.boober.service.openshift.ImageStreamInformation
+import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
+import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResponse
+import no.skatteetaten.aurora.boober.service.openshift.OpenShiftStatus
+import no.skatteetaten.aurora.boober.service.openshift.OpenshiftCommand
+import no.skatteetaten.aurora.boober.service.openshift.VerificationResult
+import org.springframework.beans.factory.annotation.Autowired
+import spock.mock.DetachedMockFactory
+
+import static no.skatteetaten.aurora.boober.model.TemplateType.build
+import static no.skatteetaten.aurora.boober.service.openshift.OperationType.CREATE
+
+@DefaultOverride(auroraConfig = false)
+class RedeployServiceTriggerRedeployTest extends AbstractMockedOpenShiftSpecification {
+
+    @Autowired
+    OpenShiftClient openShiftClient
+
+    @Autowired
+    RedeployService redeployService
+
+    OpenShiftStatus openShiftStatus
+
+    def setup() {
+        openShiftClient.createOpenShiftCommand(_, _, _) >> { new OpenshiftCommand(CREATE, it[1]) }
+        openShiftClient.performOpenShiftCommand(_, _) >> {
+            OpenshiftCommand cmd = it[1]
+            new OpenShiftResponse(cmd, cmd.payload)
+        }
+    }
+
+    def createDeploymentSpec() {
+        Permissions permissions = new Permissions(new Permission(null, null), null)
+        AuroraDeployEnvironment env = new AuroraDeployEnvironment("paas", "utv", permissions)
+        return new AuroraDeploymentSpec("v1", TemplateType.deploy, "name", new HashMap<String, Map<String, Object>>(), "dev", env, null, null, null, null, null, null)
+    }
+
+    def "Trigger redeploy service"() {
+        setup:
+            openShiftStatus = Mock(OpenShiftStatus.class)
+            openShiftStatus.didImportImage() >> false
+            openShiftStatus.hasResponse(_) >> false
+            openShiftStatus.verifyImageStreamImport() >> { new VerificationResult(true) }
+            openShiftStatus.findImageStreamInformation() >> { new ImageStreamInformation("img", "dock")}
+
+        when:
+            def result = redeployService.triggerRedeploy(createDeploymentSpec(), openShiftStatus)
+
+        then:
+            result == null
+    }
+
+}


### PR DESCRIPTION
Denne PR er kun for diskusjon. Formålet er å finne en måte å forenkle testing av RedeployService.triggerRedeploy().

Dessverre har mesteparten av tiden gått med til å slåss med Spock, og resultatet er foreløpig ikke særlig gjennomarbeidet.

Problemet slik jeg ser det er at man trenger testdadata i form av json-meldinger som representerer svarmeldinger fra OpenShift. Dette er store meldinger med kompliserte sammenghenger mellom feltene.

Jeg har plassert disse meldingene i en "container" som har logikk for å parse meldingene og tilbyr et enkelt api mot RedeployService. Da kan vi lage en mock av den nye klassen og bruke den i testen av RedeployService. 