### PR TITLE
Feature/aos 2432

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/DeployService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/DeployService.kt
@@ -165,8 +165,8 @@ class DeployService(
             val cmd = TagCommand("$dockerGroup/${it.artifactId}", it.version, it.releaseTo!!, dockerRegistry)
             dockerService.tag(cmd)
         }
-        val redeployContext = RedeployContext(openShiftResponses, deploymentSpec, openShiftObjectGenerator)
-        val redeployResult = redeployService.triggerRedeploy(redeployContext)
+        val redeployContext = RedeployContext(openShiftResponses)
+        val redeployResult = redeployService.triggerRedeploy(deploymentSpec, redeployContext)
 
         if (!redeployResult.success) {
             return result.copy(openShiftResponses = openShiftResponses.addIfNotNull(redeployResult.openShiftResponses),

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/DeployService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/DeployService.kt
@@ -165,7 +165,8 @@ class DeployService(
             val cmd = TagCommand("$dockerGroup/${it.artifactId}", it.version, it.releaseTo!!, dockerRegistry)
             dockerService.tag(cmd)
         }
-        val redeployResult = redeployService.triggerRedeploy(deploymentSpec, openShiftResponses)
+        val redeployContext = RedeployContext(openShiftResponses, deploymentSpec, openShiftObjectGenerator)
+        val redeployResult = redeployService.triggerRedeploy(redeployContext)
 
         if (!redeployResult.success) {
             return result.copy(openShiftResponses = openShiftResponses.addIfNotNull(redeployResult.openShiftResponses),

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/RedeployContext.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/RedeployContext.kt
@@ -1,0 +1,84 @@
+package no.skatteetaten.aurora.boober.service
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
+import no.skatteetaten.aurora.boober.model.TemplateType
+import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResponse
+import no.skatteetaten.aurora.boober.utils.openshiftKind
+import no.skatteetaten.aurora.boober.utils.openshiftName
+
+open class RedeployContext(private val openShiftResponses: List<OpenShiftResponse>,
+                      val deploymentSpec: AuroraDeploymentSpec,
+                      private val openShiftObjectGenerator: OpenShiftObjectGenerator) {
+
+    lateinit var redeployResource: JsonNode
+
+
+
+    fun generateRedeployResource() {
+        if (deploymentSpec.type == TemplateType.build || deploymentSpec.type == TemplateType.development) {
+            return
+        }
+
+        val imageStream = openShiftResponses.find { it.responseBody?.openshiftKind == "imagestream" }
+        val deployment = openShiftResponses.find { it.responseBody?.openshiftKind == "deploymentconfig" }
+        if (imageStream == null && deployment != null) {
+            redeployResource = openShiftObjectGenerator.generateDeploymentRequest(deploymentSpec.name) // TODO flyttes ut til RedeployService
+        }
+
+        findImageInformation(openShiftResponses)?.let { imageInformation ->
+            imageStream?.responseBody?.takeIf { it.openshiftName == imageInformation.imageStreamName }?.let {
+                val tags = it.at("/spec/tags") as ArrayNode
+                tags.find { it["name"].asText() == imageInformation.imageStreamTag }?.let {
+                    val dockerImageName = it.at("/from/name").asText()
+                    redeployResource = openShiftObjectGenerator.generateImageStreamImport(imageInformation.imageStreamName, dockerImageName) // TODO flyttes ut til RedeployService
+                }
+            }
+        }
+    }
+
+    private fun findImageInformation(openShiftResponses: List<OpenShiftResponse>): RedeployService.ImageInformation? {
+        val dc = openShiftResponses.find { it.responseBody?.openshiftKind == "deploymentconfig" }?.responseBody
+                ?: return null
+
+        val triggers = dc.at("/spec/triggers") as ArrayNode
+        return triggers.find { it["type"].asText().toLowerCase() == "imagechange" }?.let {
+            val (isName, tag) = it.at("/imageChangeParams/from/name").asText().split(':')
+            val lastTriggeredImage = it.at("/imageChangeParams/lastTriggeredImage")?.asText() ?: ""
+            RedeployService.ImageInformation(lastTriggeredImage, isName, tag)
+        }
+    }
+
+    fun verifyResponse(response: OpenShiftResponse): RedeployService.VerificationResult {
+        val body = response.responseBody ?: return RedeployService.VerificationResult(success = false, message = "No response found")
+        val images = body.at("/status/images") as? ArrayNode
+
+        images?.find { it["status"]["status"].textValue()?.toLowerCase().equals("failure") }?.let {
+            return RedeployService.VerificationResult(success = false, message = it["status"]["message"]?.textValue())
+        }
+
+        return RedeployService.VerificationResult(success = true)
+    }
+
+    fun didNotImportImageStream(imageStreamImportResponse: OpenShiftResponse) =
+            imageStreamImportResponse.command.payload.openshiftKind != "imagestreamimport" || didImportImage(imageStreamImportResponse)
+
+    private fun didImportImage(response: OpenShiftResponse): Boolean {
+        val body = response.responseBody ?: return true
+        val info = findImageInformation(openShiftResponses) ?: return true
+        if (info.lastTriggeredImage.isBlank()) {
+            return false
+        }
+
+        val tags = body.at("/status/import/status/tags") as ArrayNode
+        tags.find { it["tag"].asText() == info.imageStreamTag }?.let {
+            val allTags = it["items"] as ArrayNode
+            val tag = allTags.first()
+            return tag["dockerImageReference"].asText() != info.lastTriggeredImage
+        }
+
+        return true
+    }
+
+}

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/RedeployContext.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/RedeployContext.kt
@@ -1,41 +1,18 @@
 package no.skatteetaten.aurora.boober.service
 
-import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ArrayNode
-import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
-import no.skatteetaten.aurora.boober.model.TemplateType
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResponse
 import no.skatteetaten.aurora.boober.utils.openshiftKind
 import no.skatteetaten.aurora.boober.utils.openshiftName
 
-open class RedeployContext(private val openShiftResponses: List<OpenShiftResponse>,
-                      val deploymentSpec: AuroraDeploymentSpec,
-                      private val openShiftObjectGenerator: OpenShiftObjectGenerator) {
+open class RedeployContext(private val openShiftResponses: List<OpenShiftResponse>) {
 
-    lateinit var redeployResource: JsonNode
+    open fun getImageStream(): OpenShiftResponse? {
+        return openShiftResponses.find { it.responseBody?.openshiftKind == "imagestream" }
+    }
 
-
-
-    fun generateRedeployResource() {
-        if (deploymentSpec.type == TemplateType.build || deploymentSpec.type == TemplateType.development) {
-            return
-        }
-
-        val imageStream = openShiftResponses.find { it.responseBody?.openshiftKind == "imagestream" }
-        val deployment = openShiftResponses.find { it.responseBody?.openshiftKind == "deploymentconfig" }
-        if (imageStream == null && deployment != null) {
-            redeployResource = openShiftObjectGenerator.generateDeploymentRequest(deploymentSpec.name) // TODO flyttes ut til RedeployService
-        }
-
-        findImageInformation(openShiftResponses)?.let { imageInformation ->
-            imageStream?.responseBody?.takeIf { it.openshiftName == imageInformation.imageStreamName }?.let {
-                val tags = it.at("/spec/tags") as ArrayNode
-                tags.find { it["name"].asText() == imageInformation.imageStreamTag }?.let {
-                    val dockerImageName = it.at("/from/name").asText()
-                    redeployResource = openShiftObjectGenerator.generateImageStreamImport(imageInformation.imageStreamName, dockerImageName) // TODO flyttes ut til RedeployService
-                }
-            }
-        }
+    open fun getDeploymentConfig(): OpenShiftResponse? {
+        return openShiftResponses.find { it.responseBody?.openshiftKind == "deploymentconfig" }
     }
 
     private fun findImageInformation(openShiftResponses: List<OpenShiftResponse>): RedeployService.ImageInformation? {
@@ -50,8 +27,9 @@ open class RedeployContext(private val openShiftResponses: List<OpenShiftRespons
         }
     }
 
-    fun verifyResponse(response: OpenShiftResponse): RedeployService.VerificationResult {
-        val body = response.responseBody ?: return RedeployService.VerificationResult(success = false, message = "No response found")
+    open fun verifyResponse(response: OpenShiftResponse): RedeployService.VerificationResult {
+        val body = response.responseBody
+                ?: return RedeployService.VerificationResult(success = false, message = "No response found")
         val images = body.at("/status/images") as? ArrayNode
 
         images?.find { it["status"]["status"].textValue()?.toLowerCase().equals("failure") }?.let {
@@ -61,7 +39,7 @@ open class RedeployContext(private val openShiftResponses: List<OpenShiftRespons
         return RedeployService.VerificationResult(success = true)
     }
 
-    fun didNotImportImageStream(imageStreamImportResponse: OpenShiftResponse) =
+    open fun noImageStreamImportRequired(imageStreamImportResponse: OpenShiftResponse) =
             imageStreamImportResponse.command.payload.openshiftKind != "imagestreamimport" || didImportImage(imageStreamImportResponse)
 
     private fun didImportImage(response: OpenShiftResponse): Boolean {
@@ -79,6 +57,31 @@ open class RedeployContext(private val openShiftResponses: List<OpenShiftRespons
         }
 
         return true
+    }
+
+    open fun findImageInformation(): RedeployService.ImageInformation? {
+        val dc = openShiftResponses.find { it.responseBody?.openshiftKind == "deploymentconfig" }?.responseBody
+                ?: return null
+
+        val triggers = dc.at("/spec/triggers") as ArrayNode
+        return triggers.find { it["type"].asText().toLowerCase() == "imagechange" }?.let {
+            val (isName, tag) = it.at("/imageChangeParams/from/name").asText().split(':')
+            val lastTriggeredImage = it.at("/imageChangeParams/lastTriggeredImage")?.asText() ?: ""
+            RedeployService.ImageInformation(lastTriggeredImage, isName, tag)
+        }
+    }
+
+    open fun findImageName(): String? {
+        val imageInformation = findImageInformation()
+        imageInformation?.let { img ->
+            getImageStream()?.responseBody?.takeIf { it.openshiftName == img.imageStreamName }?.let {
+                val tags = it.at("/spec/tags") as ArrayNode
+                tags.find { it["name"].asText() == img.imageStreamTag }?.let {
+                    return it.at("/from/name").asText()
+                }
+            }
+        }
+        return null
     }
 
 }

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/RedeployServiceTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/RedeployServiceTest.groovy
@@ -1,0 +1,28 @@
+package no.skatteetaten.aurora.boober.service
+
+import com.fasterxml.jackson.databind.JsonNode
+
+import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
+import spock.lang.Specification
+
+class RedeployServiceTest extends Specification {
+  private def redeployService
+
+  void setup() {
+    redeployService = new RedeployService(Mock(OpenShiftClient), Mock(OpenShiftObjectGenerator))
+  }
+
+  def "Trigger redeploy"() {
+    given:
+      def redeployContext = Mock(RedeployContext) {
+        generateRedeployResourceFromSpec() >> Mock(JsonNode)
+      }
+
+    when:
+      redeployService.triggerRedeploy(redeployContext)
+
+    then:
+      noExceptionThrown()
+
+  }
+}

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/RedeployServiceTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/RedeployServiceTest.groovy
@@ -2,27 +2,54 @@ package no.skatteetaten.aurora.boober.service
 
 import com.fasterxml.jackson.databind.JsonNode
 
+import no.skatteetaten.aurora.boober.model.AuroraDeployEnvironment
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
+import no.skatteetaten.aurora.boober.model.Permission
+import no.skatteetaten.aurora.boober.model.Permissions
+import no.skatteetaten.aurora.boober.model.TemplateType
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
+import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResponse
+import no.skatteetaten.aurora.boober.service.openshift.OpenshiftCommand
+import no.skatteetaten.aurora.boober.service.openshift.OperationType
 import spock.lang.Specification
 
 class RedeployServiceTest extends Specification {
-  private def redeployService
+  def emptyOpenShiftResponse = new OpenShiftResponse(new OpenshiftCommand(OperationType.CREATE, Mock(JsonNode)))
+
+  def redeployService
+  def openshiftClient = Mock(OpenShiftClient)
+  def openshiftObjectGenerator = Mock(OpenShiftObjectGenerator)
+  def redeployContext = Mock(RedeployContext)
 
   void setup() {
-    redeployService = new RedeployService(Mock(OpenShiftClient), Mock(OpenShiftObjectGenerator))
+    redeployService = new RedeployService(openshiftClient, openshiftObjectGenerator)
+
+    redeployContext.getImageStream() >> emptyOpenShiftResponse
+    redeployContext.getDeploymentConfig() >> emptyOpenShiftResponse
+    redeployContext.findImageInformation() >> new RedeployService.ImageInformation('', '', '')
+    redeployContext.findImageName() >> ''
+    redeployContext.verifyResponse(emptyOpenShiftResponse) >> new RedeployService.VerificationResult()
+    redeployContext.noImageStreamImportRequired(null) >> false
+
+    openshiftObjectGenerator.generateImageStreamImport('', '') >> Mock(JsonNode)
+    openshiftClient.performOpenShiftCommand('', null) >> emptyOpenShiftResponse
   }
 
   def "Trigger redeploy"() {
     given:
-      def redeployContext = Mock(RedeployContext) {
-        generateRedeployResourceFromSpec() >> Mock(JsonNode)
-      }
+      def deploymentSpec = createAuroraDeploymentSpec()
 
     when:
-      redeployService.triggerRedeploy(redeployContext)
+      def response = redeployService.triggerRedeploy(deploymentSpec, redeployContext)
 
     then:
-      noExceptionThrown()
+      response.success
+  }
 
+  private static AuroraDeploymentSpec createAuroraDeploymentSpec() {
+    new AuroraDeploymentSpec('', TemplateType.deploy, '', [:], '',
+        new AuroraDeployEnvironment('', '', new Permissions(new Permission(null, null), null)), null, null, null,
+        null,
+        null, null)
   }
 }


### PR DESCRIPTION
A new attempt at refactoring the trigger redeploy feature.

I have tried to take into account the comments added to this PR #171, but unfortunately I have not been able to fix all suggestions. This is also work-in-progress, so any suggestions to improvements are welcome :)

**The major changes include:**
- Added RedeployContext to wrap the json functionality, making it easier to test the triggerRedeploy method. The only input to this class is the list of openshift responses. The class is meant to be immutable and is therefore created in the DeployService. Not sure if the name of this class is good enough...
- Tried to split up the triggerRedeploy into smaller methods with more readable names. I have done my best to give them appropriate names, but I have a feeling someone who knows the code better than me can suggest improvements on this. One of the major focus areas for me was to keep the abstraction in the method at the same level, avoiding code that for instance handles json parsing.
-  Fixed existing tests and added a new RedeployServiceTest. There needs to be more tests added to the RedeployServiceTest class, but I think it is a good idea to get feedback on this before moving on. I know that this test contains a lot of mocking at the moment, so there might be better ways of testing it.

