### PR TITLE
AOS-2445 always add the basic secretVault handler

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraVolumeMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraVolumeMapperV1.kt
@@ -28,19 +28,11 @@ class AuroraVolumeMapperV1(private val applicationFiles: List<AuroraConfigFile>)
     }
 
     private fun createSecretVaultHandlers(): List<AuroraConfigFieldHandler> {
-        val secretVaultSubKeys = applicationFiles.findSubKeys("secretVault")
+        val keyName = "secretVault"
+        val secretVaultSubKeysHandlers = applicationFiles.findSubKeys(keyName)
+                .map { AuroraConfigFieldHandler("$keyName/$it") }
 
-        val handlers = listOf(AuroraConfigFieldHandler("secretVault"))
-        //no subkeys means this is the old format. Return fieldHandler for "secretVault"
-        if (secretVaultSubKeys.isEmpty()) {
-            return handlers
-        }
-
-        return secretVaultSubKeys.flatMap { secretVaultSubKey ->
-            listOf(
-                    AuroraConfigFieldHandler("secretVault/$secretVaultSubKey")
-            )
-        } + handlers
+        return secretVaultSubKeysHandlers + AuroraConfigFieldHandler(keyName)
     }
 
     private fun createMountHandlers(): List<AuroraConfigFieldHandler> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraVolumeMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraVolumeMapperV1.kt
@@ -30,18 +30,17 @@ class AuroraVolumeMapperV1(private val applicationFiles: List<AuroraConfigFile>)
     private fun createSecretVaultHandlers(): List<AuroraConfigFieldHandler> {
         val secretVaultSubKeys = applicationFiles.findSubKeys("secretVault")
 
+        val handlers = listOf(AuroraConfigFieldHandler("secretVault"))
         //no subkeys means this is the old format. Return fieldHandler for "secretVault"
         if (secretVaultSubKeys.isEmpty()) {
-            return listOf(
-                    AuroraConfigFieldHandler("secretVault")
-            )
+            return handlers
         }
 
         return secretVaultSubKeys.flatMap { secretVaultSubKey ->
             listOf(
                     AuroraConfigFieldHandler("secretVault/$secretVaultSubKey")
             )
-        }
+        } + handlers
     }
 
     private fun createMountHandlers(): List<AuroraConfigFieldHandler> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraVolumeMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraVolumeMapperV1.kt
@@ -28,11 +28,11 @@ class AuroraVolumeMapperV1(private val applicationFiles: List<AuroraConfigFile>)
     }
 
     private fun createSecretVaultHandlers(): List<AuroraConfigFieldHandler> {
-        val keyName = "secretVault"
-        val secretVaultSubKeysHandlers = applicationFiles.findSubKeys(keyName)
-                .map { AuroraConfigFieldHandler("$keyName/$it") }
-
-        return secretVaultSubKeysHandlers + AuroraConfigFieldHandler(keyName)
+        return listOf(
+                AuroraConfigFieldHandler("secretVault"),
+                AuroraConfigFieldHandler("secretVault/name"),
+                AuroraConfigFieldHandler("secretVault/keys")
+        )
     }
 
     private fun createMountHandlers(): List<AuroraConfigFieldHandler> {

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecValidatorTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecValidatorTest.groovy
@@ -169,4 +169,16 @@ class AuroraDeploymentSpecValidatorTest extends AbstractAuroraDeploymentSpecTest
     expect:
       specValidator.validateVaultExistence(deploymentSpec)
   }
+
+  def "should handle overrides of secretVaultKeys with different syntax"() {
+    given:
+      auroraConfigJson["utv/about.json"] = '''{ "secretVault": "foo", "cluster" : "utv" }'''
+      auroraConfigJson["utv/aos-simple.json"] = '''{ "secretVault": { "name":"foo2" }}'''
+
+    when:
+      def deploymentSpec = createDeploymentSpec(auroraConfigJson, DEFAULT_AID)
+
+    then:
+      deploymentSpec.volume.secretVaultName == "foo2"
+  }
 }


### PR DESCRIPTION
When doing exteneded/simple config we need to remember that some files can have simple config and others advanced. So we always need to push all the handlers. 