### PR TITLE
Bugfix/aos 2573 ao cluster

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecMapperV1.kt
@@ -24,38 +24,39 @@ import no.skatteetaten.aurora.boober.utils.pattern
 
 class AuroraDeploymentSpecMapperV1(val applicationId: ApplicationId) {
 
-
     val envNamePattern = "^[a-z0-9\\-]{0,52}$"
     val envNameMessage = "Environment must consist of lower case alphanumeric characters or '-'. It must be no longer than 52 characters."
     val handlers = listOf(
-            AuroraConfigFieldHandler("affiliation", validator = { it.pattern("^[a-z]{1,10}$", "Affiliation can only contain letters and must be no longer than 10 characters") }),
-            AuroraConfigFieldHandler("cluster", validator = { it.notBlank("Cluster must be set") }),
-            AuroraConfigFieldHandler("permissions/admin"),
-            AuroraConfigFieldHandler("permissions/view"),
-            AuroraConfigFieldHandler("permissions/adminServiceAccount"),
-            // Max length of OpenShift project names is 63 characters. Project name = affiliation + "-" + envName.
-            AuroraConfigFieldHandler("envName", validator = { it.pattern(envNamePattern, envNameMessage) },
-                    defaultSource = "folderName",
-                    defaultValue = applicationId.environment
-            ),
-            AuroraConfigFieldHandler("env/name", validator = { it.pattern(envNamePattern, envNameMessage, false) }),
-            AuroraConfigFieldHandler("env/ttl", validator = { it.durationString() }),
-            AuroraConfigFieldHandler("name",
-                    defaultValue = applicationId.application,
-                    defaultSource = "fileName",
-                    validator = { it.pattern(namePattern, "Name must be alphanumeric and no more than 40 characters", false) }),
-            AuroraConfigFieldHandler("splunkIndex"),
-            AuroraConfigFieldHandler("certificate/commonName"),
-            AuroraConfigFieldHandler("certificate"),
-            AuroraConfigFieldHandler("database"),
-            AuroraConfigFieldHandler("prometheus", defaultValue = true),
-            AuroraConfigFieldHandler("prometheus/path", defaultValue = "/prometheus"),
-            AuroraConfigFieldHandler("prometheus/port", defaultValue = 8081),
-            AuroraConfigFieldHandler("management", defaultValue = true),
-            AuroraConfigFieldHandler("management/path", defaultValue = "actuator"),
-            AuroraConfigFieldHandler("management/port", defaultValue = "8081"),
-            AuroraConfigFieldHandler("deployStrategy/type", defaultValue = "rolling", validator = { it.oneOf(listOf("recreate", "rolling")) }),
-            AuroraConfigFieldHandler("deployStrategy/timeout", defaultValue = 180)
+        AuroraConfigFieldHandler("applicationId", defaultValue = applicationId.toString(),
+            validator = { it.pattern("^$applicationId$", "ApplicationId can't be changed") }),
+        AuroraConfigFieldHandler("affiliation", validator = { it.pattern("^[a-z]{1,10}$", "Affiliation can only contain letters and must be no longer than 10 characters") }),
+        AuroraConfigFieldHandler("cluster", validator = { it.notBlank("Cluster must be set") }),
+        AuroraConfigFieldHandler("permissions/admin"),
+        AuroraConfigFieldHandler("permissions/view"),
+        AuroraConfigFieldHandler("permissions/adminServiceAccount"),
+        // Max length of OpenShift project names is 63 characters. Project name = affiliation + "-" + envName.
+        AuroraConfigFieldHandler("envName", validator = { it.pattern(envNamePattern, envNameMessage) },
+            defaultSource = "folderName",
+            defaultValue = applicationId.environment
+        ),
+        AuroraConfigFieldHandler("env/name", validator = { it.pattern(envNamePattern, envNameMessage, false) }),
+        AuroraConfigFieldHandler("env/ttl", validator = { it.durationString() }),
+        AuroraConfigFieldHandler("name",
+            defaultValue = applicationId.application,
+            defaultSource = "fileName",
+            validator = { it.pattern(namePattern, "Name must be alphanumeric and no more than 40 characters", false) }),
+        AuroraConfigFieldHandler("splunkIndex"),
+        AuroraConfigFieldHandler("certificate/commonName"),
+        AuroraConfigFieldHandler("certificate"),
+        AuroraConfigFieldHandler("database"),
+        AuroraConfigFieldHandler("prometheus", defaultValue = true),
+        AuroraConfigFieldHandler("prometheus/path", defaultValue = "/prometheus"),
+        AuroraConfigFieldHandler("prometheus/port", defaultValue = 8081),
+        AuroraConfigFieldHandler("management", defaultValue = true),
+        AuroraConfigFieldHandler("management/path", defaultValue = "actuator"),
+        AuroraConfigFieldHandler("management/port", defaultValue = "8081"),
+        AuroraConfigFieldHandler("deployStrategy/type", defaultValue = "rolling", validator = { it.oneOf(listOf("recreate", "rolling")) }),
+        AuroraConfigFieldHandler("deployStrategy/timeout", defaultValue = 180)
     )
 
     fun createAuroraDeploymentSpec(auroraConfigFields: AuroraConfigFields,
@@ -69,28 +70,28 @@ class AuroraDeploymentSpecMapperV1(val applicationId: ApplicationId) {
         val name: String = auroraConfigFields.extract("name")
 
         return AuroraDeploymentSpec(
-                schemaVersion = auroraConfigFields.extract("schemaVersion"),
-                applicationPlatform = auroraConfigFields.extract("applicationPlatform"),
-                type = auroraConfigFields.extract("type"),
-                name = name,
+            applicationId = applicationId,
+            schemaVersion = auroraConfigFields.extract("schemaVersion"),
+            applicationPlatform = auroraConfigFields.extract("applicationPlatform"),
+            type = auroraConfigFields.extract("type"),
+            name = name,
 
-                cluster = auroraConfigFields.extract("cluster"),
-                environment = AuroraDeployEnvironment(
-                        affiliation = auroraConfigFields.extract("affiliation"),
-                        envName = auroraConfigFields.extractIfExistsOrNull("env/name")
-                                ?: auroraConfigFields.extract("envName"),
-                        ttl = auroraConfigFields.extractOrNull<String>("env/ttl")
-                                ?.let { StringToDurationConverter().convert(it) },
-                        permissions = extractPermissions(auroraConfigFields)
-                ),
-                fields = createMapForAuroraDeploymentSpecPointers(createFieldsWithValues(auroraConfigFields, build)),
-                volume = volume,
-                route = route,
-                build = build,
-                deploy = deploy,
-                template = template,
-                localTemplate = localTemplate)
-
+            cluster = auroraConfigFields.extract("cluster"),
+            environment = AuroraDeployEnvironment(
+                affiliation = auroraConfigFields.extract("affiliation"),
+                envName = auroraConfigFields.extractIfExistsOrNull("env/name")
+                    ?: auroraConfigFields.extract("envName"),
+                ttl = auroraConfigFields.extractOrNull<String>("env/ttl")
+                    ?.let { StringToDurationConverter().convert(it) },
+                permissions = extractPermissions(auroraConfigFields)
+            ),
+            fields = createMapForAuroraDeploymentSpecPointers(createFieldsWithValues(auroraConfigFields, build)),
+            volume = volume,
+            route = route,
+            build = build,
+            deploy = deploy,
+            template = template,
+            localTemplate = localTemplate)
     }
 
     private fun createIncludeSubKeysMap(fields: Map<String, AuroraConfigField>): Map<String, Boolean> {
@@ -98,18 +99,17 @@ class AuroraDeploymentSpecMapperV1(val applicationId: ApplicationId) {
         val includeSubKeys = mutableMapOf<String, Boolean>()
 
         fields.entries
-                .filter { it.key.split("/").size == 1 }
-                .forEach {
-                    val key = it.key.split("/")[0]
-                    val shouldIncludeSubKeys = it.value.valueOrDefault?.let {
-                        !it.isBoolean || it.booleanValue()
-                    } ?: false
-                    includeSubKeys.put(key, shouldIncludeSubKeys)
-                }
+            .filter { it.key.split("/").size == 1 }
+            .forEach {
+                val key = it.key.split("/")[0]
+                val shouldIncludeSubKeys = it.value.valueOrDefault?.let {
+                    !it.isBoolean || it.booleanValue()
+                } ?: false
+                includeSubKeys.put(key, shouldIncludeSubKeys)
+            }
 
         return includeSubKeys
     }
-
 
     fun createMapForAuroraDeploymentSpecPointers(auroraConfigFields: Map<String, AuroraConfigField>): Map<String, Map<String, Any?>> {
         val fields = mutableMapOf<String, Any?>()
@@ -133,8 +133,8 @@ class AuroraDeploymentSpecMapperV1(val applicationId: ApplicationId) {
             keys.forEachIndexed { index, key ->
                 if (index == keys.lastIndex) {
                     next[key] = mutableMapOf(
-                            "source" to (configField.source?.configName ?: configField.handler.defaultSource),
-                            "value" to configField.valueOrDefault
+                        "source" to (configField.source?.configName ?: configField.handler.defaultSource),
+                        "value" to configField.valueOrDefault
                     )
                 } else {
                     if (next[key] == null) {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraDeploymentSpecMapperV1.kt
@@ -112,7 +112,7 @@ class AuroraDeploymentSpecMapperV1(val applicationId: ApplicationId) {
     fun createFields(applicationId: ApplicationId, auroraConfigFields: AuroraConfigFields, build: AuroraBuild?): Map<String, Map<String, Any?>> {
         val applicationIdField = mapOf("applicationId" to mapOf(
             "source" to "static",
-            "value" to applicationId
+            "value" to applicationId.toString()
         ))
 
         val fields = createMapForAuroraDeploymentSpecPointers(createFieldsWithValues(auroraConfigFields, build))

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpec.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraDeploymentSpec.kt
@@ -25,6 +25,7 @@ data class AuroraDeployEnvironment(
 }
 
 data class AuroraDeploymentSpec(
+        val applicationId: ApplicationId,
         val schemaVersion: String,
         val type: TemplateType,
         val name: String,

--- a/src/test/groovy/no/skatteetaten/aurora/boober/contracts/AuroradeploymentspecBase.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/contracts/AuroradeploymentspecBase.groovy
@@ -1,6 +1,7 @@
 package no.skatteetaten.aurora.boober.contracts
 
 import no.skatteetaten.aurora.boober.controller.v1.AuroraDeploymentSpecControllerV1
+import no.skatteetaten.aurora.boober.model.ApplicationId
 import no.skatteetaten.aurora.boober.model.AuroraDeployEnvironment
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.model.Permission
@@ -24,7 +25,7 @@ class AuroradeploymentspecBase extends AbstractContractBase {
 
   private AuroraDeploymentSpec createAuroraDeploymentSpec() {
     def deploymentSpecs = response('deploymentspec', '$.items[0]', Map)
-    new AuroraDeploymentSpec('', TemplateType.development, '', deploymentSpecs, '', '',
+    new AuroraDeploymentSpec(new ApplicationId('', ''), '', TemplateType.development, '', deploymentSpecs, '', '',
         new AuroraDeployEnvironment('', '',
             new Permissions(new Permission(Collections.emptySet(), Collections.emptySet()), null), null),
         null, null, null, null, null, null)

--- a/src/test/groovy/no/skatteetaten/aurora/boober/contracts/DeployBase.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/contracts/DeployBase.groovy
@@ -1,6 +1,7 @@
 package no.skatteetaten.aurora.boober.contracts
 
 import no.skatteetaten.aurora.boober.controller.v1.DeployControllerV1
+import no.skatteetaten.aurora.boober.model.ApplicationId
 import no.skatteetaten.aurora.boober.model.AuroraDeployEnvironment
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.model.Permission
@@ -30,7 +31,7 @@ class DeployBase extends AbstractContractBase {
       reason = response('deploy-failed', '$.message', String)
     }
 
-    def spec = new AuroraDeploymentSpec('', TemplateType.development, '', [:], '', '',
+    def spec = new AuroraDeploymentSpec(new ApplicationId('', ''), '', TemplateType.development, '', [:], '', '',
         new AuroraDeployEnvironment('', '',
             new Permissions(new Permission(Collections.emptySet(), Collections.emptySet()), null), null),
         null, null, null, null, null, null)

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-formatted-withDefaults.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-formatted-withDefaults.txt
@@ -1,8 +1,8 @@
 {
+  applicationId:       utv/reference            // static
   schemaVersion:       "v1"                     // about.json
   type:                "deploy"                 // reference.json
   applicationPlatform: "java"                   // default
-  applicationId:       "utv/reference"          // default
   affiliation:         "aos"                    // about.json
   cluster:             "utv"                    // utv/about.json
   permissions: {

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-formatted-withDefaults.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-formatted-withDefaults.txt
@@ -2,6 +2,7 @@
   schemaVersion:       "v1"                     // about.json
   type:                "deploy"                 // reference.json
   applicationPlatform: "java"                   // default
+  applicationId:       "utv/reference"          // default
   affiliation:         "aos"                    // about.json
   cluster:             "utv"                    // utv/about.json
   permissions: {

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-formatted.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-formatted.txt
@@ -1,4 +1,5 @@
 {
+  applicationId:       utv/reference            // static
   schemaVersion:       "v1"                     // about.json
   type:                "deploy"                 // reference.json
   affiliation:         "aos"                    // about.json

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-withDefaults.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-withDefaults.json
@@ -11,6 +11,10 @@
     "source": "default",
     "value": "java"
   },
+  "applicationId": {
+    "source": "default",
+    "value": "utv/reference"
+  },
   "affiliation": {
     "source": "about.json",
     "value": "aos"

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-withDefaults.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference-withDefaults.json
@@ -1,4 +1,8 @@
 {
+  "applicationId": {
+    "source": "static",
+    "value": "utv/reference"
+  },
   "schemaVersion": {
     "source": "about.json",
     "value": "v1"
@@ -10,10 +14,6 @@
   "applicationPlatform": {
     "source": "default",
     "value": "java"
-  },
-  "applicationId": {
-    "source": "default",
-    "value": "utv/reference"
   },
   "affiliation": {
     "source": "about.json",

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/reference.json
@@ -1,4 +1,8 @@
 {
+  "applicationId": {
+    "source": "static",
+    "value": "utv/reference"
+  },
   "schemaVersion": {
     "source": "about.json",
     "value": "v1"

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted-withDefaults.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted-withDefaults.txt
@@ -2,6 +2,7 @@
   schemaVersion:       "v1"                        // about.json
   type:                "development"               // utv/webleveranse.json
   applicationPlatform: "web"                       // webleveranse.json
+  applicationId:       "utv/webleveranse"          // default
   affiliation:         "aos"                       // about.json
   cluster:             "utv"                       // utv/about.json
   permissions: {

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted-withDefaults.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted-withDefaults.txt
@@ -1,8 +1,8 @@
 {
+  applicationId:       utv/webleveranse            // static
   schemaVersion:       "v1"                        // about.json
   type:                "development"               // utv/webleveranse.json
   applicationPlatform: "web"                       // webleveranse.json
-  applicationId:       "utv/webleveranse"          // default
   affiliation:         "aos"                       // about.json
   cluster:             "utv"                       // utv/about.json
   permissions: {

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted.txt
@@ -1,4 +1,5 @@
 {
+  applicationId:       utv/webleveranse            // static
   schemaVersion:       "v1"                        // about.json
   type:                "development"               // utv/webleveranse.json
   applicationPlatform: "web"                       // webleveranse.json

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-withDefaults.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-withDefaults.json
@@ -11,6 +11,10 @@
     "source": "webleveranse.json",
     "value": "web"
   },
+  "applicationId": {
+    "source": "default",
+    "value": "utv/webleveranse"
+  },
   "affiliation": {
     "source": "about.json",
     "value": "aos"

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-withDefaults.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-withDefaults.json
@@ -1,4 +1,8 @@
 {
+  "applicationId": {
+    "source": "static",
+    "value": "utv/webleveranse"
+  },
   "schemaVersion": {
     "source": "about.json",
     "value": "v1"
@@ -10,10 +14,6 @@
   "applicationPlatform": {
     "source": "webleveranse.json",
     "value": "web"
-  },
-  "applicationId": {
-    "source": "default",
-    "value": "utv/webleveranse"
   },
   "affiliation": {
     "source": "about.json",

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse.json
@@ -1,4 +1,8 @@
 {
+  "applicationId": {
+    "source": "static",
+    "value": "utv/webleveranse"
+  },
   "schemaVersion": {
     "source": "about.json",
     "value": "v1"


### PR DESCRIPTION
For å kunne gjøre en deploy med --cluster flagget satt på AO deploy, trenger vi applicationId i AuroraDeploymentSpec.

ao deploy med clusterflagg - steg:

1. Henter filenames
2. Filtrer på fuzzymatch
3. Henter ADC for resultatet av fuzzy
4. Filtrerer ADC på cluster.
(Her er feilen som ble rapportert i AOS-2573) Jeg brukte resultatet av fuzzy til deploy og ikke resultatet av filtrering av cluster. Uten applicationId er det ikke mulig å gjøre en deploy av resultatet fra filtreringen.
(5. Deploy)