### PR TITLE
AOS-2608 Validate keys in secret vault

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/PropertiesUtil.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/PropertiesUtil.kt
@@ -23,6 +23,11 @@ fun Properties.filter(keys: List<String>): Properties {
     }
 
     val propertyNames = this.stringPropertyNames()
+    val missingKeys = keys - propertyNames
+    if (missingKeys.isNotEmpty()) {
+        throw IllegalArgumentException("The keys $missingKeys were not found in the secret vault")
+    }
+
     val newProps = Properties()
     keys.filter { propertyNames.contains(it) }
         .map { it to this.getProperty(it) }

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/resourceprovisioning/VaultProviderTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/resourceprovisioning/VaultProviderTest.groovy
@@ -1,0 +1,44 @@
+package no.skatteetaten.aurora.boober.service.resourceprovisioning
+
+import org.springframework.core.io.ByteArrayResource
+import org.springframework.core.io.support.PropertiesLoaderUtils
+
+import no.skatteetaten.aurora.boober.service.vault.EncryptedFileVault
+import no.skatteetaten.aurora.boober.service.vault.VaultService
+import spock.lang.Specification
+
+class VaultProviderTest extends Specification {
+
+  static COLLECTION_NAME = "paas"
+  static VAULT_NAME = "test"
+
+  private VaultService vaultService
+  private VaultProvider vaultProvider
+
+  void setup() {
+
+    vaultService = Mock(VaultService) {
+      findVault(COLLECTION_NAME, VAULT_NAME) >>
+          EncryptedFileVault.createFromFolder(new File('./src/test/resources/samples/config/secret/'))
+    }
+    vaultProvider = new VaultProvider(vaultService)
+  }
+
+  def "Find filtered vault data"() {
+    given:
+      def requests = [new VaultRequest(COLLECTION_NAME, VAULT_NAME, ['Boober'], [:])]
+
+    when:
+      def results = vaultProvider.findVaultData(requests)
+      def properties = loadProperties(results)
+
+    then:
+      results.vaultIndex.size() == 1
+      properties['Boober'] == '1'
+  }
+
+  private static Properties loadProperties(VaultResults results) {
+    def vaultData = results.getVaultData(VAULT_NAME)
+    PropertiesLoaderUtils.loadProperties(new ByteArrayResource(vaultData['latest.properties']))
+  }
+}

--- a/src/test/groovy/no/skatteetaten/aurora/boober/utils/PropertiesUtilTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/utils/PropertiesUtilTest.groovy
@@ -22,14 +22,12 @@ something=sameting
       !filteredProps.stringPropertyNames().containsAll(['foo', 'something'])
   }
 
-  def "Remove correct elements when key list contain unknown keys"() {
+  def "Throw IllegalArgumentException when filtering with a key that is not available in properties"() {
     when:
-      byte[] filteredBytes = PropertiesUtilKt.filterProperties(props, ['username', 'unknown'], [:])
+      PropertiesUtilKt.filterProperties(props, ['username', 'unknown'], [:])
 
     then:
-      Properties filteredProps = loadProperties(filteredBytes)
-      filteredProps.size() == 1
-      filteredProps.stringPropertyNames()[0] == 'username'
+      thrown(IllegalArgumentException)
   }
 
   def "Replace filtered key mappings"() {


### PR DESCRIPTION
I have added a verification when filtering the property keys that checks if the configured keys contain values that are not present in the properties (secret vault). If there are values returned it will throw an IllegalArgumentException.

Is this the correct way to handle the failure? Or do I need to do something more in boober to get this properly displayed in ao?