### PR TITLE
AOS-2666 ApplicationId

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/AuroraConfigField.kt
@@ -86,13 +86,8 @@ class AuroraConfigFields(val fields: Map<String, AuroraConfigField>) {
         }.toMap()
     }
 
-    fun getKeyMappings(keyMappingsExtractors: List<AuroraConfigFieldHandler>): Map<String, String>? {
-        return keyMappingsExtractors.map {
-            val field = it.name.substringAfterLast("/")
-            val value: String = extract(it.name)
-            field to value
-        }.toMap()
-    }
+    fun getKeyMappings(keyMappingsExtractor: AuroraConfigFieldHandler?): Map<String, String>? =
+        keyMappingsExtractor?.let { extractIfExistsOrNull(it.name) }
 
     fun disabledAndNoSubKeys(name: String): Boolean {
 
@@ -142,7 +137,11 @@ class AuroraConfigFields(val fields: Map<String, AuroraConfigField>) {
 
         val logger: Logger = LoggerFactory.getLogger(AuroraConfigFields::class.java)
 
-        fun create(handlers: Set<AuroraConfigFieldHandler>, files: List<AuroraConfigFile>, placeholders: Map<String, String> = emptyMap()): AuroraConfigFields {
+        fun create(
+            handlers: Set<AuroraConfigFieldHandler>,
+            files: List<AuroraConfigFile>,
+            placeholders: Map<String, String> = emptyMap()
+        ): AuroraConfigFields {
 
             val replacer = StringSubstitutor(placeholders, "@", "@")
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftObjectLabelService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftObjectLabelService.kt
@@ -1,6 +1,7 @@
 package no.skatteetaten.aurora.boober.service
 
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
+import org.apache.commons.codec.digest.DigestUtils
 import org.springframework.stereotype.Service
 
 @Service
@@ -49,6 +50,10 @@ class OpenShiftObjectLabelService(private val userDetailsProvider: UserDetailsPr
             "updateInBoober" to "true",
             "booberDeployId" to deployId
         )
-        return toOpenShiftLabelNameSafeMap(labels + additionalLabels)
+
+        val deploy = auroraDeploymentSpec.deploy ?: return toOpenShiftLabelNameSafeMap(labels + additionalLabels)
+        return toOpenShiftLabelNameSafeMap(
+            mapOf("appId" to DigestUtils.sha1Hex("${deploy.groupId}/${deploy.artifactId}")) + labels + additionalLabels
+        )
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessor.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessor.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResourceClient
+import org.apache.commons.codec.digest.DigestUtils
 import org.springframework.stereotype.Service
 
 @Service
@@ -61,7 +62,7 @@ class OpenShiftTemplateProcessor(
 
         if (!labels.has("appId")) {
             template["metadata"]?.get("name")?.let {
-                labels.put("appId", it.asText())
+                labels.put("appId", DigestUtils.sha1Hex(it.asText()))
             }
         }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessor.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessor.kt
@@ -59,6 +59,12 @@ class OpenShiftTemplateProcessor(
             labels.put("template", template)
         }
 
+        if (!labels.has("appId")) {
+            template["metadata"]?.get("name")?.let {
+                labels.put("appId", it.asText())
+            }
+        }
+
         if (!labels.has("app")) {
             labels.put("app", auroraDeploymentSpec.name)
         }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -16,6 +16,10 @@ fun JsonNode.findAllPointers(maxLevel: Int): List<String> {
         if (root.startsWith("/mount") && root.split("/").size > maxLevel) {
             return listOf(root)
         }
+        if (root.startsWith("/secretVault/keyMappings")) {
+            return listOf()
+        }
+
         val ret = mutableListOf<String>()
         for ((key, child) in node.fields()) {
             val newKey = "$root/$key"
@@ -155,6 +159,7 @@ fun JsonNode?.length(length: Int, message: String, required: Boolean = true): Ex
     return null
 }
 
-fun jacksonYamlObjectMapper(): ObjectMapper = ObjectMapper(YAMLFactory().enable(JsonParser.Feature.ALLOW_COMMENTS)).registerKotlinModule()
+fun jacksonYamlObjectMapper(): ObjectMapper =
+    ObjectMapper(YAMLFactory().enable(JsonParser.Feature.ALLOW_COMMENTS)).registerKotlinModule()
 
 fun jsonMapper(): ObjectMapper = jacksonObjectMapper().enable(JsonParser.Feature.ALLOW_COMMENTS)

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftObjectGeneratorTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftObjectGeneratorTest.groovy
@@ -75,9 +75,9 @@ class OpenShiftObjectGeneratorTest extends AbstractOpenShiftObjectGeneratorTest 
 
       env           | name            | templateFile      | overrides
       "booberdev"   | "tvinn"         | "atomhopper.json" | []
-        "booberdev" | "reference"     | null              | []
-        "booberdev" | "console"       | null              | []
-        "webseal"   | "sprocket"      | null              | []
+      "booberdev"   | "reference"     | null              | []
+      "booberdev"   | "console"       | null              | []
+      "webseal"     | "sprocket"      | null              | []
       "booberdev"   | "sprocket"      | null              | []
       "booberdev"   | "reference-web" | null              | []
       "booberdev"   | "build"         | null              | []

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessorTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessorTest.groovy
@@ -1,14 +1,29 @@
 package no.skatteetaten.aurora.boober.service
 
+import java.time.Duration
+
+import org.springframework.http.ResponseEntity
+
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 
+import no.skatteetaten.aurora.boober.controller.security.User
+import no.skatteetaten.aurora.boober.model.ApplicationId
+import no.skatteetaten.aurora.boober.model.AuroraConfigFile
+import no.skatteetaten.aurora.boober.model.AuroraDeployEnvironment
+import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
+import no.skatteetaten.aurora.boober.model.Permission
+import no.skatteetaten.aurora.boober.model.Permissions
+import no.skatteetaten.aurora.boober.model.TemplateType
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResourceClient
 
 class OpenShiftTemplateProcessorTest extends AbstractSpec {
 
   ObjectMapper mapper = new ObjectMapper()
-  def templateProcessor = new OpenShiftTemplateProcessor(Mock(UserDetailsProvider), Mock(OpenShiftResourceClient),
+  def templateProcessor = new OpenShiftTemplateProcessor(
+      Mock(UserDetailsProvider) { getAuthenticatedUser() >> new User('username', 'token', '', []) },
+      Mock(OpenShiftResourceClient),
       mapper)
   String template = loadResource("jenkins-cluster-persistent-2.0.json")
   JsonNode templateJson = mapper.readValue(template, JsonNode)
@@ -50,5 +65,40 @@ class OpenShiftTemplateProcessorTest extends AbstractSpec {
 
     then:
       !errors.isEmpty()
+  }
+
+  def "Generate template object with labels"() {
+    given:
+      def openshiftClient = Mock(OpenShiftResourceClient)
+    templateProcessor = new OpenShiftTemplateProcessor(templateProcessor.userDetailsProvider, openshiftClient, mapper)
+
+    when:
+      def objects = templateProcessor.generateObjects(templateJson as ObjectNode, [:], createEmptyDeploymentSpec(), "1", 0)
+
+    then:
+      1 * openshiftClient.post(_ as String, _ as String, null, _ as ObjectNode) >> {
+        String kind, String namespace, String name, ObjectNode payload ->
+          assertLabels(payload['labels'] as ObjectNode)
+          ResponseEntity.ok(payload)
+     }
+      objects.size() > 0
+  }
+
+  private static void assertLabels(ObjectNode labels) {
+    assert labels['affiliation'] != null
+    assert labels['template'].asText() == 'jenkins-cluster-persistent'
+    assert labels['appId'].asText() == 'jenkins-cluster-persistent-2.0'
+    assert labels['app'] != null
+    assert labels['updatedBy'].asText() == 'username'
+    assert labels['updateInBoober'] == null
+  }
+
+  private static createEmptyDeploymentSpec() {
+    new AuroraDeploymentSpec(new ApplicationId('', ''), '', TemplateType.development, '', [:],
+        '', '', new AuroraDeployEnvironment('', '',
+        new Permissions(new Permission(new HashSet<String>(), new HashSet<String>()),
+            new Permission(new HashSet<String>(), new HashSet<String>())),
+        Duration.ofMinutes(30)),
+        null, null, null, null, null, null, null, new AuroraConfigFile("", "", false), "master")
   }
 }

--- a/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessorTest.groovy
+++ b/src/test/groovy/no/skatteetaten/aurora/boober/service/OpenShiftTemplateProcessorTest.groovy
@@ -2,6 +2,7 @@ package no.skatteetaten.aurora.boober.service
 
 import java.time.Duration
 
+import org.apache.commons.codec.digest.DigestUtils
 import org.springframework.http.ResponseEntity
 
 import com.fasterxml.jackson.databind.JsonNode
@@ -70,7 +71,7 @@ class OpenShiftTemplateProcessorTest extends AbstractSpec {
   def "Generate template object with labels"() {
     given:
       def openshiftClient = Mock(OpenShiftResourceClient)
-    templateProcessor = new OpenShiftTemplateProcessor(templateProcessor.userDetailsProvider, openshiftClient, mapper)
+      templateProcessor = new OpenShiftTemplateProcessor(templateProcessor.userDetailsProvider, openshiftClient, mapper)
 
     when:
       def objects = templateProcessor.generateObjects(templateJson as ObjectNode, [:], createEmptyDeploymentSpec(), "1", 0)
@@ -87,7 +88,7 @@ class OpenShiftTemplateProcessorTest extends AbstractSpec {
   private static void assertLabels(ObjectNode labels) {
     assert labels['affiliation'] != null
     assert labels['template'].asText() == 'jenkins-cluster-persistent'
-    assert labels['appId'].asText() == 'jenkins-cluster-persistent-2.0'
+    assert labels['appId'].asText() == DigestUtils.sha1Hex('jenkins-cluster-persistent-2.0')
     assert labels['app'] != null
     assert labels['updatedBy'].asText() == 'username'
     assert labels['updateInBoober'] == null

--- a/src/test/resources/samples/result/booberdev/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/booberdev/aos-simple/buildconfig.json
@@ -3,6 +3,7 @@
   "kind": "BuildConfig",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/aos-simple/configmap.json
+++ b/src/test/resources/samples/result/booberdev/aos-simple/configmap.json
@@ -3,6 +3,7 @@
   "kind": "ConfigMap",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/aos-simple/deploymentconfig.json
+++ b/src/test/resources/samples/result/booberdev/aos-simple/deploymentconfig.json
@@ -9,6 +9,7 @@
       "sprocket.sits.no/deployment-config.certificate": "ske.aurora.openshift.aos-simple"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -34,6 +35,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "7abf72388235de0b5602f884db4200295ed23837",
           "app": "aos-simple",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/aos-simple/imagestream.json
+++ b/src/test/resources/samples/result/booberdev/aos-simple/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/aos-simple/route.json
+++ b/src/test/resources/samples/result/booberdev/aos-simple/route.json
@@ -6,6 +6,7 @@
       "haproxy.router.openshift.io/timeout": "30s"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/aos-simple/service.json
+++ b/src/test/resources/samples/result/booberdev/aos-simple/service.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/service.webseal-roles": "admin dev"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/console/deploymentconfig.json
+++ b/src/test/resources/samples/result/booberdev/console/deploymentconfig.json
@@ -8,6 +8,7 @@
       "console.skatteetaten.no/management-path": ":8082/actuator"
     },
     "labels": {
+      "appId": "1d8c6374126c0a5f2e0592eb3d44cbc681a42c8a",
       "app": "openshift-console-api",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -36,6 +37,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "1d8c6374126c0a5f2e0592eb3d44cbc681a42c8a",
           "app": "openshift-console-api",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/console/imagestream.json
+++ b/src/test/resources/samples/result/booberdev/console/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "1d8c6374126c0a5f2e0592eb3d44cbc681a42c8a",
       "app": "openshift-console-api",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/console/route.json
+++ b/src/test/resources/samples/result/booberdev/console/route.json
@@ -3,6 +3,7 @@
   "kind": "Route",
   "metadata": {
     "labels": {
+      "appId": "1d8c6374126c0a5f2e0592eb3d44cbc681a42c8a",
       "app": "openshift-console-api",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/console/service.json
+++ b/src/test/resources/samples/result/booberdev/console/service.json
@@ -10,6 +10,7 @@
       "sprocket.sits.no/service.webseal": "webseal"
     },
     "labels": {
+      "appId": "1d8c6374126c0a5f2e0592eb3d44cbc681a42c8a",
       "app": "openshift-console-api",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference-web/buildconfig.json
+++ b/src/test/resources/samples/result/booberdev/reference-web/buildconfig.json
@@ -3,6 +3,7 @@
   "kind": "BuildConfig",
   "metadata": {
     "labels": {
+      "appId": "1590fc38ff96cbe228a5003e20e3ef3893e8bc06",
       "app": "openshift-referanse-react",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference-web/deploymentconfig.json
+++ b/src/test/resources/samples/result/booberdev/reference-web/deploymentconfig.json
@@ -8,6 +8,7 @@
       "console.skatteetaten.no/management-path": ":8081/actuator"
     },
     "labels": {
+      "appId": "1590fc38ff96cbe228a5003e20e3ef3893e8bc06",
       "app": "openshift-referanse-react",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -36,6 +37,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "1590fc38ff96cbe228a5003e20e3ef3893e8bc06",
           "app": "openshift-referanse-react",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference-web/imagestream.json
+++ b/src/test/resources/samples/result/booberdev/reference-web/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "1590fc38ff96cbe228a5003e20e3ef3893e8bc06",
       "app": "openshift-referanse-react",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference-web/route.json
+++ b/src/test/resources/samples/result/booberdev/reference-web/route.json
@@ -6,6 +6,7 @@
 
     },
     "labels": {
+      "appId": "1590fc38ff96cbe228a5003e20e3ef3893e8bc06",
       "app": "openshift-referanse-react",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference-web/service.json
+++ b/src/test/resources/samples/result/booberdev/reference-web/service.json
@@ -9,6 +9,7 @@
       "prometheus.io/port": "8081"
     },
     "labels": {
+      "appId": "1590fc38ff96cbe228a5003e20e3ef3893e8bc06",
       "app": "openshift-referanse-react",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference/deploymentconfig.json
+++ b/src/test/resources/samples/result/booberdev/reference/deploymentconfig.json
@@ -9,6 +9,7 @@
       "sprocket.sits.no/deployment-config.certificate": "no.skatteetaten.aurora.openshift.reference"
     },
     "labels": {
+      "appId": "4f99affe6e2316fd3de91e788ea622ea29563c8e",
       "app": "reference",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -38,6 +39,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "4f99affe6e2316fd3de91e788ea622ea29563c8e",
           "app": "reference",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference/imagestream.json
+++ b/src/test/resources/samples/result/booberdev/reference/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "4f99affe6e2316fd3de91e788ea622ea29563c8e",
       "app": "reference",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference/route.json
+++ b/src/test/resources/samples/result/booberdev/reference/route.json
@@ -3,6 +3,7 @@
   "kind": "Route",
   "metadata": {
     "labels": {
+      "appId": "4f99affe6e2316fd3de91e788ea622ea29563c8e",
       "app": "reference",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/reference/service.json
+++ b/src/test/resources/samples/result/booberdev/reference/service.json
@@ -9,6 +9,7 @@
       "prometheus.io/port": "8081"
     },
     "labels": {
+      "appId": "4f99affe6e2316fd3de91e788ea622ea29563c8e",
       "app": "reference",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/sprocket/deploymentconfig.json
+++ b/src/test/resources/samples/result/booberdev/sprocket/deploymentconfig.json
@@ -8,6 +8,7 @@
       "console.skatteetaten.no/management-path": ":8081/foobar"
     },
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -36,6 +37,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
           "app": "sprocket",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/sprocket/imagestream.json
+++ b/src/test/resources/samples/result/booberdev/sprocket/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/sprocket/service.json
+++ b/src/test/resources/samples/result/booberdev/sprocket/service.json
@@ -9,6 +9,7 @@
       "prometheus.io/port": "8082"
     },
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/booberdev/sprocket/sprocketconfig.json
+++ b/src/test/resources/samples/result/booberdev/sprocket/sprocketconfig.json
@@ -3,6 +3,7 @@
   "kind": "ConfigMap",
   "metadata": {
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/mounts/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/buildconfig.json
@@ -3,6 +3,7 @@
   "kind": "BuildConfig",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/mounts/aos-simple/configmap.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/configmap.json
@@ -3,6 +3,7 @@
   "kind": "ConfigMap",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/mounts/aos-simple/deploymentconfig.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/deploymentconfig.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/deployment-config.certificate": "ske.aurora.openshift.aos-simple"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -36,6 +37,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "7abf72388235de0b5602f884db4200295ed23837",
           "app": "aos-simple",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/mounts/aos-simple/imagestream.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/mounts/aos-simple/route.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/route.json
@@ -6,6 +6,7 @@
       "haproxy.router.openshift.io/timeout": "30s"
     },
     "labels": {
+    "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/mounts/aos-simple/route2.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/route2.json
@@ -6,6 +6,7 @@
       "haproxy.router.openshift.io/timeout": "30s"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/mounts/aos-simple/service.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/service.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/service.webseal-roles": "admin dev"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/release/aos-simple/deploymentconfig.json
+++ b/src/test/resources/samples/result/release/aos-simple/deploymentconfig.json
@@ -9,6 +9,7 @@
       "sprocket.sits.no/deployment-config.certificate": "ske.aurora.openshift.aos-simple"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -37,6 +38,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "7abf72388235de0b5602f884db4200295ed23837",
           "app": "aos-simple",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/release/aos-simple/imagestream.json
+++ b/src/test/resources/samples/result/release/aos-simple/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/release/aos-simple/route.json
+++ b/src/test/resources/samples/result/release/aos-simple/route.json
@@ -6,6 +6,7 @@
       "haproxy.router.openshift.io/timeout": "30s"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/release/aos-simple/service.json
+++ b/src/test/resources/samples/result/release/aos-simple/service.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/service.webseal-roles": "admin dev"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secretmount/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/buildconfig.json
@@ -3,6 +3,7 @@
   "kind": "BuildConfig",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secretmount/aos-simple/deploymentconfig.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/deploymentconfig.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/deployment-config.certificate": "ske.aurora.openshift.aos-simple"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -36,6 +37,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "7abf72388235de0b5602f884db4200295ed23837",
           "app": "aos-simple",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/secretmount/aos-simple/imagestream.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secretmount/aos-simple/route.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/route.json
@@ -6,6 +6,7 @@
       "haproxy.router.openshift.io/timeout": "30s"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secretmount/aos-simple/secret.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/secret.json
@@ -3,6 +3,7 @@
   "kind": "Secret",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secretmount/aos-simple/service.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/service.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/service.webseal-roles": "admin dev"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secrettest/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/secrettest/aos-simple/buildconfig.json
@@ -3,6 +3,7 @@
   "kind": "BuildConfig",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secrettest/aos-simple/deploymentconfig.json
+++ b/src/test/resources/samples/result/secrettest/aos-simple/deploymentconfig.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/deployment-config.certificate": "tullball"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -36,6 +37,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "7abf72388235de0b5602f884db4200295ed23837",
           "app": "aos-simple",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/secrettest/aos-simple/imagestream.json
+++ b/src/test/resources/samples/result/secrettest/aos-simple/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secrettest/aos-simple/route.json
+++ b/src/test/resources/samples/result/secrettest/aos-simple/route.json
@@ -6,6 +6,7 @@
       "haproxy.router.openshift.io/timeout": "30s"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secrettest/aos-simple/secret.json
+++ b/src/test/resources/samples/result/secrettest/aos-simple/secret.json
@@ -3,6 +3,7 @@
   "kind": "Secret",
   "metadata": {
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/secrettest/aos-simple/service.json
+++ b/src/test/resources/samples/result/secrettest/aos-simple/service.json
@@ -8,6 +8,7 @@
       "sprocket.sits.no/service.webseal-roles": "admin dev"
     },
     "labels": {
+      "appId": "7abf72388235de0b5602f884db4200295ed23837",
       "app": "aos-simple",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/webseal/sprocket/deploymentconfig.json
+++ b/src/test/resources/samples/result/webseal/sprocket/deploymentconfig.json
@@ -8,6 +8,7 @@
       "console.skatteetaten.no/management-path": ":8081/foobar"
     },
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",
@@ -36,6 +37,7 @@
     "template": {
       "metadata": {
         "labels": {
+          "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
           "app": "sprocket",
           "updatedBy": "hero",
           "affiliation": "aos",

--- a/src/test/resources/samples/result/webseal/sprocket/imagestream.json
+++ b/src/test/resources/samples/result/webseal/sprocket/imagestream.json
@@ -3,6 +3,7 @@
   "kind": "ImageStream",
   "metadata": {
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/webseal/sprocket/service.json
+++ b/src/test/resources/samples/result/webseal/sprocket/service.json
@@ -10,6 +10,7 @@
       "sprocket.sits.no/service.webseal": "sprocket-aos-webseal"
     },
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",

--- a/src/test/resources/samples/result/webseal/sprocket/sprocketconfig.json
+++ b/src/test/resources/samples/result/webseal/sprocket/sprocketconfig.json
@@ -3,6 +3,7 @@
   "kind": "ConfigMap",
   "metadata": {
     "labels": {
+      "appId": "ad8a6ae72753e0f49ab0f2aeb73ee124ad29e7ac",
       "app": "sprocket",
       "updatedBy": "hero",
       "affiliation": "aos",


### PR DESCRIPTION
AppId is created by groupId/artifactId and then generating a SHA1 of the string.
This is done to avoid problems the limitations of openshift labels.

For templates the template name is used as appId.