### PR TITLE
Suggested not using reified generics to pass class as parameter

### DIFF
--- a/src/test/kotlin/no/skatteetaten/aurora/boober/contracts/AuroradeploymentspecBase.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/contracts/AuroradeploymentspecBase.kt
@@ -12,7 +12,7 @@ open class AuroradeploymentspecBase {
 
     @BeforeEach
     fun setUp() {
-        contractResponses(AuroradeploymentspecBase::class) {
+        contractResponses(this) {
             val auroraDeploymentSpecService = mockk<AuroraDeploymentSpecService>().apply {
                 every { getAuroraDeploymentSpecs(any(), any()) } returns listOf(AuroraDeploymentSpec(emptyMap()))
             }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/contracts/AuroradeploymentspecBase.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/contracts/AuroradeploymentspecBase.kt
@@ -12,7 +12,7 @@ open class AuroradeploymentspecBase {
 
     @BeforeEach
     fun setUp() {
-        contractResponses<AuroradeploymentspecBase> {
+        contractResponses(AuroradeploymentspecBase::class) {
             val auroraDeploymentSpecService = mockk<AuroraDeploymentSpecService>().apply {
                 every { getAuroraDeploymentSpecs(any(), any()) } returns listOf(AuroraDeploymentSpec(emptyMap()))
             }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/contracts/ContractBase.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/contracts/ContractBase.kt
@@ -10,7 +10,6 @@ import org.bouncycastle.asn1.x500.style.RFC4519Style.name
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import java.io.File
-import kotlin.reflect.KClass
 
 class ContractResponses(val jsonResponses: Map<String, DocumentContext>) {
     inline fun <reified T : Any> response(responseName: String): T {
@@ -20,14 +19,14 @@ class ContractResponses(val jsonResponses: Map<String, DocumentContext>) {
     }
 }
 
-fun contractResponses(baseClass: KClass<*>, fn: (responses: ContractResponses) -> Any) {
-    val baseName = baseClass.simpleName
-        ?: throw IllegalArgumentException("Invalid base object, ${baseClass.simpleName}")
+fun contractResponses(baseTestObject: Any, fn: (responses: ContractResponses) -> Any) {
+    val baseName = baseTestObject::class.simpleName
+        ?: throw IllegalArgumentException("Invalid base object, ${baseTestObject::class.simpleName}")
     contractResponses(baseName, fn)
 }
 
 fun contractResponses(baseName: String, fn: (responses: ContractResponses) -> Any) {
-    val folderName = "/contracts/${baseName.toLowerCase().removeSuffix("base")}/responses"
+    val folderName = "/contracts/${baseName.toLowerCase().removeSuffix("test")}/responses"
     val content = object {}.javaClass.getResource(folderName)
 
     val files = File(content.toURI()).walk().filter { it.name.endsWith(".json") }.toList()


### PR DESCRIPTION
Jeg foreslår i dette tilfellet å ikke bruke reified generics for å sende klassen som skal brukes til å utlede mappen med kontrakter. Grunnen til dette er at dersom den generiske parameteren ikke brukes til å utlede typen til enten én eller flere av de øvrige parameterne til metoden, eller returverdien, er den generiske parameteren i praksis en ordinær parameter. Det vil si at i konteksten til kalleren av metoden må man alltid spesifisere den generiske typen siden den ikke kan utledes. I praksis blir dette da bare en alternativ måte å sende parametre til metoden på som kun kan brukes for klasser. F.eks. dersom man istedenfor å utlede "baseName" fra klassens simpleName sendte "baseName" direkte ville man måtte bruke en ordinær string-parameter. I eksempelet mitt har jeg overloadet contractResponses-metoden for å illustrere dette poenget.

Jeg syntes også det blir vanskeligere å forstå hvilken rolle den generiske parameteren har i metoden, siden man (vanligvis) ikke navngir de generiske parameterne på samme måte som ordinære metodeparametre. F.eks., etter min vurdering, er

`fun contractResponses(baseClass: KClass<*>, fn: (responses: ContractResponses) -> Any)`

lettere å forstå enn

`inline fun <reified T : Any> contractResponses(fn: (responses: ContractResponses) -> Any)`

Det kommer ikke så tydelig fram fra signaturen hva T gjør her - i motsetning til når T brukes for å spesifisere typer til parametre eller returverdier.

Så poenget mitt er at på et generelt grunnlag vil jeg si at man ikke bør bruke reified generics til å sende klasser som parametre til metoder dersom de ikke kan utledes fra contexten til kalleren. Og derfor mener jeg altså at i dette tilfellet så bør man kanskje heller ikke bruke reified generics.

Hva tenker du?