### PR TITLE
removed baseImage handlers from AuroraBuildMapperV1

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/ApplicationPlatformHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/ApplicationPlatformHandler.kt
@@ -24,6 +24,7 @@ import no.skatteetaten.aurora.boober.model.MountType.ConfigMap
 import no.skatteetaten.aurora.boober.model.MountType.PVC
 import no.skatteetaten.aurora.boober.model.MountType.Secret
 import no.skatteetaten.aurora.boober.model.Probe
+import no.skatteetaten.aurora.boober.model.TemplateType
 import no.skatteetaten.aurora.boober.service.OpenShiftObjectLabelService
 import no.skatteetaten.aurora.boober.service.internal.createDbEnv
 import no.skatteetaten.aurora.boober.utils.addIfNotNull
@@ -33,7 +34,7 @@ import no.skatteetaten.aurora.boober.utils.withNonBlank
 import java.time.Duration
 
 abstract class ApplicationPlatformHandler(val name: String) {
-    open fun handlers(handlers: Set<AuroraConfigFieldHandler>): Set<AuroraConfigFieldHandler> = handlers
+    open fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = emptySet()
 
     abstract fun handleAuroraDeployment(
         auroraDeploymentSpecInternal: AuroraDeploymentSpecInternal,

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/JavaPlatformHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/JavaPlatformHandler.kt
@@ -4,6 +4,7 @@ import no.skatteetaten.aurora.boober.mapper.AuroraConfigFieldHandler
 import no.skatteetaten.aurora.boober.mapper.v1.PortNumbers
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpecInternal
 import no.skatteetaten.aurora.boober.model.Mount
+import no.skatteetaten.aurora.boober.model.TemplateType
 import no.skatteetaten.aurora.boober.model.TemplateType.development
 import no.skatteetaten.aurora.boober.utils.addIfNotNull
 import org.springframework.stereotype.Component
@@ -54,16 +55,11 @@ class JavaPlatformHandler : ApplicationPlatformHandler("java") {
         )
     }
 
-    override fun handlers(handlers: Set<AuroraConfigFieldHandler>): Set<AuroraConfigFieldHandler> {
-
-        val buildHandlers = handlers.find { it.name.startsWith("baseImage") }
-            ?.let {
-                setOf(
-                    AuroraConfigFieldHandler("baseImage/name", defaultValue = "flange"),
-                    AuroraConfigFieldHandler("baseImage/version", defaultValue = "8")
-                )
-            }
-
-        return handlers.addIfNotNull(buildHandlers)
+    override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when(type) {
+        development -> setOf(
+            AuroraConfigFieldHandler("baseImage/name", defaultValue = "flange"),
+            AuroraConfigFieldHandler("baseImage/version", defaultValue = "8")
+        )
+        else -> emptySet()
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/JavaPlatformHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/JavaPlatformHandler.kt
@@ -55,7 +55,7 @@ class JavaPlatformHandler : ApplicationPlatformHandler("java") {
         )
     }
 
-    override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when(type) {
+    override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when (type) {
         development -> setOf(
             AuroraConfigFieldHandler("baseImage/name", defaultValue = "wingnut8"),
             AuroraConfigFieldHandler("baseImage/version", defaultValue = "1")

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/JavaPlatformHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/JavaPlatformHandler.kt
@@ -57,8 +57,8 @@ class JavaPlatformHandler : ApplicationPlatformHandler("java") {
 
     override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when(type) {
         development -> setOf(
-            AuroraConfigFieldHandler("baseImage/name", defaultValue = "flange"),
-            AuroraConfigFieldHandler("baseImage/version", defaultValue = "8")
+            AuroraConfigFieldHandler("baseImage/name", defaultValue = "wingnut8"),
+            AuroraConfigFieldHandler("baseImage/version", defaultValue = "1")
         )
         else -> emptySet()
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/WebPlatformHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/WebPlatformHandler.kt
@@ -65,11 +65,11 @@ class WebPlatformHandler : ApplicationPlatformHandler("web") {
         )
     }
 
-    override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when(type) {
+    override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when (type) {
         development -> setOf(
-                AuroraConfigFieldHandler("baseImage/name", defaultValue = "wrench8"),
-                AuroraConfigFieldHandler("baseImage/version", defaultValue = "1")
-            )
+            AuroraConfigFieldHandler("baseImage/name", defaultValue = "wrench8"),
+            AuroraConfigFieldHandler("baseImage/version", defaultValue = "1")
+        )
         else -> emptySet()
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/WebPlatformHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/WebPlatformHandler.kt
@@ -67,8 +67,8 @@ class WebPlatformHandler : ApplicationPlatformHandler("web") {
 
     override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when(type) {
         development -> setOf(
-                AuroraConfigFieldHandler("baseImage/name", defaultValue = "wrench"),
-                AuroraConfigFieldHandler("baseImage/version", defaultValue = "0")
+                AuroraConfigFieldHandler("baseImage/name", defaultValue = "wrench8"),
+                AuroraConfigFieldHandler("baseImage/version", defaultValue = "1")
             )
         else -> emptySet()
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/WebPlatformHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/platform/WebPlatformHandler.kt
@@ -4,6 +4,7 @@ import no.skatteetaten.aurora.boober.mapper.AuroraConfigFieldHandler
 import no.skatteetaten.aurora.boober.mapper.v1.PortNumbers
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpecInternal
 import no.skatteetaten.aurora.boober.model.Mount
+import no.skatteetaten.aurora.boober.model.TemplateType
 import no.skatteetaten.aurora.boober.model.TemplateType.development
 import no.skatteetaten.aurora.boober.utils.addIfNotNull
 import org.springframework.stereotype.Component
@@ -64,14 +65,11 @@ class WebPlatformHandler : ApplicationPlatformHandler("web") {
         )
     }
 
-    override fun handlers(handlers: Set<AuroraConfigFieldHandler>): Set<AuroraConfigFieldHandler> {
-
-        val buildHandlers = handlers.find { it.name.startsWith("baseImage") }?.let {
-            setOf(
+    override fun handlers(type: TemplateType): Set<AuroraConfigFieldHandler> = when(type) {
+        development -> setOf(
                 AuroraConfigFieldHandler("baseImage/name", defaultValue = "wrench"),
                 AuroraConfigFieldHandler("baseImage/version", defaultValue = "0")
             )
-        }
-        return handlers.addIfNotNull(buildHandlers)
+        else -> emptySet()
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraBuildMapperV1.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/mapper/v1/AuroraBuildMapperV1.kt
@@ -38,8 +38,6 @@ class AuroraBuildMapperV1(
     val handlers = listOf(
         AuroraConfigFieldHandler("builder/name", defaultValue = "architect"),
         AuroraConfigFieldHandler("builder/version", defaultValue = "1"),
-        AuroraConfigFieldHandler("baseImage/name"),
-        AuroraConfigFieldHandler("baseImage/version"),
         AuroraConfigFieldHandler(
             "groupId",
             validator = { it.length(200, "GroupId must be set and be shorter then 200 characters") }),

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecService.kt
@@ -103,7 +103,7 @@ class AuroraDeploymentSpecService(
                     TemplateType.template -> routeMapper.handlers + volumeMapper.handlers + templateMapper.handlers
                 }).toSet()
 
-            val handlers = applicationHandler.handlers(rawHandlers)
+            val handlers = rawHandlers + applicationHandler.handlers(header.type)
 
             val deploymentSpec = AuroraDeploymentSpec.create(
                 handlers = handlers,

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted-withDefaults.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-formatted-withDefaults.txt
@@ -65,7 +65,7 @@
     version:                "1"                          // default
   }
   baseImage: {
-    name:                   "wrench"                     // default
-    version:                "0"                          // default
+    name:                   "wrench8"                    // default
+    version:                "1"                          // default
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-withDefaults.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecRendererTest/webleveranse-withDefaults.json
@@ -502,21 +502,21 @@
   "baseImage": {
     "name": {
       "source": "default",
-      "value": "wrench",
+      "value": "wrench8",
       "sources": [
         {
           "name": "default",
-          "value": "wrench"
+          "value": "wrench8"
         }
       ]
     },
     "version": {
       "source": "default",
-      "value": "0",
+      "value": "1",
       "sources": [
         {
           "name": "default",
-          "value": "0"
+          "value": "1"
         }
       ]
     }

--- a/src/test/resources/samples/result/booberdev/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/booberdev/aos-simple/buildconfig.json
@@ -44,11 +44,11 @@
           },
           {
             "name": "DOCKER_BASE_VERSION",
-            "value": "8"
+            "value": "1"
           },
           {
             "name": "DOCKER_BASE_IMAGE",
-            "value": "aurora/flange"
+            "value": "aurora/wingnut8"
           },
           {
             "name": "PUSH_EXTRA_TAGS",

--- a/src/test/resources/samples/result/booberdev/reference-web/buildconfig.json
+++ b/src/test/resources/samples/result/booberdev/reference-web/buildconfig.json
@@ -44,11 +44,11 @@
           },
           {
             "name": "DOCKER_BASE_VERSION",
-            "value": "0"
+            "value": "1"
           },
           {
             "name": "DOCKER_BASE_IMAGE",
-            "value": "aurora/wrench"
+            "value": "aurora/wrench8"
           },
           {
             "name": "PUSH_EXTRA_TAGS",

--- a/src/test/resources/samples/result/mounts/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/mounts/aos-simple/buildconfig.json
@@ -44,11 +44,11 @@
           },
           {
             "name": "DOCKER_BASE_VERSION",
-            "value": "8"
+            "value": "1"
           },
           {
             "name": "DOCKER_BASE_IMAGE",
-            "value": "aurora/flange"
+            "value": "aurora/wingnut8"
           },
           {
             "name": "PUSH_EXTRA_TAGS",

--- a/src/test/resources/samples/result/secretmount/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/secretmount/aos-simple/buildconfig.json
@@ -44,11 +44,11 @@
           },
           {
             "name": "DOCKER_BASE_VERSION",
-            "value": "8"
+            "value": "1"
           },
           {
             "name": "DOCKER_BASE_IMAGE",
-            "value": "aurora/flange"
+            "value": "aurora/wingnut8"
           },
           {
             "name": "PUSH_EXTRA_TAGS",

--- a/src/test/resources/samples/result/secrettest/aos-simple/buildconfig.json
+++ b/src/test/resources/samples/result/secrettest/aos-simple/buildconfig.json
@@ -44,11 +44,11 @@
           },
           {
             "name": "DOCKER_BASE_VERSION",
-            "value": "8"
+            "value": "1"
           },
           {
             "name": "DOCKER_BASE_IMAGE",
-            "value": "aurora/flange"
+            "value": "aurora/wingnut8"
           },
           {
             "name": "PUSH_EXTRA_TAGS",


### PR DESCRIPTION
Fjernet baseImage handlers fra AuroraBuildMapper da det ble 2 av samme handlers hvis baseImage var satt i tillegg til defaults. Når det ble gjort om til Set ble den siste fjernet og default var da gjeldene.