### PR TITLE
Feature/aos 3127 handle 403

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/ApplicationDeploymentService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/ApplicationDeploymentService.kt
@@ -6,6 +6,7 @@ import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResourceClient
 import no.skatteetaten.aurora.boober.service.openshift.OpenshiftCommand
 import no.skatteetaten.aurora.boober.service.openshift.OperationType
+import org.apache.http.HttpStatus
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -73,7 +74,11 @@ class ApplicationDeploymentService(
             val openshiftResponse =
                 openShiftClient.performOpenShiftCommand(it.applicationRef.namespace, it.cmd)
 
-            if (!openshiftResponse.success) {
+            val forbidden = openshiftResponse.httpErrorCode?.let {
+                it == HttpStatus.SC_FORBIDDEN
+            } ?: false
+
+            if (!openshiftResponse.success && !forbidden) {
                 logger.error(openshiftResponse.exception)
                 GetApplicationDeploymentResponse(
                     applicationRef = it.applicationRef,

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/ApplicationDeploymentService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/ApplicationDeploymentService.kt
@@ -78,7 +78,14 @@ class ApplicationDeploymentService(
                 it == HttpStatus.SC_FORBIDDEN
             } ?: false
 
-            if (!openshiftResponse.success && !forbidden) {
+            if (forbidden) {
+                GetApplicationDeploymentResponse(
+                    applicationRef = it.applicationRef,
+                    exists = false,
+                    success = true,
+                    message = "OK"
+                )
+            } else if (!openshiftResponse.success) {
                 logger.error(openshiftResponse.exception)
                 GetApplicationDeploymentResponse(
                     applicationRef = it.applicationRef,

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftClient.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftClient.kt
@@ -44,7 +44,8 @@ data class OpenShiftResponse @JvmOverloads constructor(
     val command: OpenshiftCommand,
     val responseBody: JsonNode? = null,
     val success: Boolean = true,
-    val exception: String? = null
+    val exception: String? = null,
+    val httpErrorCode: Int? = null
 ) {
 
     companion object {
@@ -59,7 +60,12 @@ data class OpenShiftResponse @JvmOverloads constructor(
             } else {
                 null
             }
-            return OpenShiftResponse(command, response, success = false, exception = e.message)
+            val httpCode = if (e.cause is HttpClientErrorException) {
+                e.cause.statusCode.value()
+            } else {
+                null
+            }
+            return OpenShiftResponse(command, response, success = false, exception = e.message, httpErrorCode = httpCode)
         }
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/service/ApplicationDeploymentServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/service/ApplicationDeploymentServiceTest.kt
@@ -91,7 +91,7 @@ class ApplicationDeploymentServiceTest {
     @Test
     fun `get ApplicationDeployments given OpenShift Error return Response with failure`() {
         val response = MockResponse()
-            .setResponseCode(403)
+            .setResponseCode(400)
             .setJsonFileAsBody("no/skatteetaten/aurora/boober/service/ApplicationDeployment/ApplicationDeploymentOpenshiftError.json")
 
         val requests = server.execute(response, response) {


### PR DESCRIPTION
If the OpenShift application deployment resource query returns 403 forbidden, then this should not be treated as a error, but instead be handled as if the resource does not exist. 

A new field, httpErrorCode, has been addred to OpenShiftResponse in order to provide information about the roor error cause back to the ApplicationDeploymentService. 