### PR TITLE
Feature/aos 4077 deploy paused applications fails

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftDeployer.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftDeployer.kt
@@ -22,6 +22,7 @@ import no.skatteetaten.aurora.boober.service.RedeployService
 import no.skatteetaten.aurora.boober.service.TagCommand
 import no.skatteetaten.aurora.boober.service.UserDetailsProvider
 import no.skatteetaten.aurora.boober.utils.addIfNotNull
+import no.skatteetaten.aurora.boober.utils.openshiftKind
 import no.skatteetaten.aurora.boober.utils.parallelMap
 import no.skatteetaten.aurora.boober.utils.whenFalse
 import org.springframework.beans.factory.annotation.Value
@@ -238,7 +239,13 @@ class OpenShiftDeployer(
             mergeWithExistingResource
         )
 
+        val shouldSleepBeforeDc = objects.last().openshiftKind == "deploymentconfig"
         val openShiftApplicationResponses: List<OpenShiftResponse> = objects.flatMap {
+
+            if (it.openshiftKind == "deploymentconfig" && shouldSleepBeforeDc) {
+                Thread.sleep(500)
+            }
+
             openShiftCommandBuilder.createAndApplyObjects(namespace, it, mergeWithExistingResource)
         }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -79,7 +79,7 @@ spring:
 management.server.port : 9091
 
 server:
-    port: 9090
+    port: 8080
 
 openshift:
     cluster: utv


### PR DESCRIPTION
Deploying a new version of an paused application sometimes fails due to a racing condition. 
A short sleep before creating deployment configuration fixes this problem. This solution is a bit hackish but this part of the code will soon be replaced anyway.
