### PR TITLE
Bufix/aos 5247

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/FluentbitSidecarFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/FluentbitSidecarFeature.kt
@@ -63,13 +63,7 @@ class FluentbitSidecarFeature(
     @Value("\${splunk.fluentbit.image}") val fluentBitImage: String
 ) : Feature {
     override fun enable(header: AuroraDeploymentSpec): Boolean {
-        val isOfType = header.type in listOf(
-            TemplateType.deploy,
-            TemplateType.development,
-            TemplateType.template,
-            TemplateType.localTemplate
-        )
-        return isOfType
+        return true
     }
 
     override fun handlers(header: AuroraDeploymentSpec, cmd: AuroraContextCommand): Set<AuroraConfigFieldHandler> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/FluentbitSidecarFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/FluentbitSidecarFeature.kt
@@ -62,9 +62,6 @@ class FluentbitSidecarFeature(
     @Value("\${splunk.hec.port}") val splunkPort: String,
     @Value("\${splunk.fluentbit.image}") val fluentBitImage: String
 ) : Feature {
-    override fun enable(header: AuroraDeploymentSpec): Boolean {
-        return true
-    }
 
     override fun handlers(header: AuroraDeploymentSpec, cmd: AuroraContextCommand): Set<AuroraConfigFieldHandler> {
         return knownLogs.map { log ->

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/FluentbitSidecarFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/FluentbitSidecarFeatureTest.kt
@@ -57,6 +57,23 @@ class FluentbitSidecarFeatureTest : AbstractFeatureTest() {
     }
 
     @Test
+    fun `should validate but not generate sidecar setup for cronjob`() {
+        val (dcResource) = generateResources(
+            """{
+             "type" : "cronjob",
+             "logging": {
+                "index": "test-index"
+             }
+           }""",
+            createEmptyDeploymentConfig(), emptyList(), 0)
+        assertThat(dcResource).isNotNull()
+        val config = dcResource.resource as DeploymentConfig
+        val annotations = config.spec.template.metadata.annotations
+        assertThat(annotations).isNotNull()
+        assertThat(annotations.get("splunk.com/index")).equals("test-index")
+    }
+
+    @Test
     fun `should validate and not generate sidecar setup for templates with empty index`() {
         val (dcResource) = generateResources(
             """{


### PR DESCRIPTION
Now boober allows all deployment types to use new logger syntax in aurora config.