### PR TITLE
SITJ-1089 Add projected service account token as mount type

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
@@ -286,7 +286,7 @@ fun List<Mount>.podVolumes(appName: String): List<Volume> {
                 }
                 MountType.PSAT -> {
                     projected {
-                        name = volumeName
+                        name = it.volumeName
                         defaultMode = 420
                         sources = listOf(newVolumeProjection {
                             serviceAccountToken = ServiceAccountTokenProjection(it.audience, it.expirationSeconds, it.volumeName)

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
@@ -72,7 +72,7 @@ class MountFeature(
                 ),
                 AuroraConfigFieldHandler("mounts/$mountName/secretVault"),
                 AuroraConfigFieldHandler("mounts/$mountName/audience"),
-                AuroraConfigFieldHandler("mounts/$mountName/expiration")
+                AuroraConfigFieldHandler("mounts/$mountName/expirationSeconds")
             )
         }.toSet()
     }
@@ -222,7 +222,7 @@ class MountFeature(
             val volumeName: String = auroraDeploymentSpec["mounts/$mount/volumeName"]
             val exist: Boolean = auroraDeploymentSpec["mounts/$mount/exist"]
             val audience = auroraDeploymentSpec.getOrNull<String?>("mounts/$mount/audience")
-            val expiration = auroraDeploymentSpec.getOrNull<Long?>("mounts/$mount/expiration")
+            val expirationSeconds = auroraDeploymentSpec.getOrNull<Long?>("mounts/$mount/expirationSeconds")
             Mount(
                 path = auroraDeploymentSpec["mounts/$mount/path"],
                 type = type,
@@ -231,7 +231,7 @@ class MountFeature(
                 exist = exist,
                 secretVaultName = secretVaultName,
                 audience = audience,
-                expiration = expiration
+                expirationSeconds = expirationSeconds
             )
         }
     }
@@ -263,7 +263,7 @@ fun List<Mount>.podVolumes(appName: String): List<Volume> {
                         name = volumeName
                         defaultMode = 420
                         sources = listOf(newVolumeProjection {
-                            serviceAccountToken = ServiceAccountTokenProjection(it.audience, it.expiration, "psat")
+                            serviceAccountToken = ServiceAccountTokenProjection(it.audience, it.expirationSeconds, it.volumeName)
                         })
                     }
                 }
@@ -287,7 +287,7 @@ data class Mount(
     val secretVaultName: String? = null,
     val targetContainer: String? = null,
     val audience: String? = null,
-    val expiration: Long? = null
+    val expirationSeconds: Long? = null
 ) {
     fun getNamespacedVolumeName(appName: String): String {
         val name = if (exist) {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
@@ -146,6 +146,7 @@ class MountFeature(
 
         val errors = validateExistinAndSecretVault(mounts)
             .addIfNotNull(validatePSATMounts(mounts))
+            .addIfNotNull(ensureCompatibleKuberntesForPSATMounts(mounts))
         // .addIfNotNull(validatePVCMounts(mounts))
         if (!fullValidation || adc.cluster != cluster) {
             return errors
@@ -155,8 +156,26 @@ class MountFeature(
             .addIfNotNull(validateVaultExistence(mounts, adc))
     }
 
+    /**
+     * @return true if given semver version is found to be higher or equal to kubernetes semver version
+     */
+    private fun k8sVersionOfAtLeast(ensure: String): Boolean {
+        val k8s = openShiftClient.version().split(".")
+        val v = ensure.split(".")
+        for (index in 0 until Math.min(k8s.size, v.size)) {
+            if (k8s[index].toInt() < v[index].toInt()) return false
+        }
+        return true
+    }
+
+    private fun ensureCompatibleKuberntesForPSATMounts(mounts: List<Mount>): List<Exception> {
+        return mounts.filter() { it.type == MountType.PSAT && !k8sVersionOfAtLeast("1.16") }.map {
+            AuroraDeploymentSpecValidationException("PSAT mount=${it.volumeName} is not valid, as kubernetes version is below 1.16")
+        }
+    }
+
     private fun validatePSATMounts(mounts: List<Mount>): List<Exception> {
-        return mounts.filter { it.exist && it.expirationSeconds != null && it.expirationSeconds < 600L }.map {
+        return mounts.filter { it.type == MountType.PSAT && (it.expirationSeconds == null || it.expirationSeconds < 600L) }.map {
             AuroraDeploymentSpecValidationException("PSAT mount=${it.volumeName} cannot have expirationSeconds less than 600s")
         }
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
@@ -4,9 +4,12 @@ import com.fkorotkov.kubernetes.metadata
 import com.fkorotkov.kubernetes.newSecret
 import com.fkorotkov.kubernetes.newVolume
 import com.fkorotkov.kubernetes.newVolumeMount
+import com.fkorotkov.kubernetes.newVolumeProjection
 import com.fkorotkov.kubernetes.persistentVolumeClaim
+import com.fkorotkov.kubernetes.projected
 import com.fkorotkov.kubernetes.secret
 import io.fabric8.kubernetes.api.model.Secret
+import io.fabric8.kubernetes.api.model.ServiceAccountTokenProjection
 import io.fabric8.kubernetes.api.model.Volume
 import io.fabric8.kubernetes.api.model.VolumeMount
 import no.skatteetaten.aurora.boober.model.AuroraConfigFieldHandler
@@ -67,7 +70,9 @@ class MountFeature(
                     validator = { it.boolean() },
                     defaultValue = false
                 ),
-                AuroraConfigFieldHandler("mounts/$mountName/secretVault")
+                AuroraConfigFieldHandler("mounts/$mountName/secretVault"),
+                AuroraConfigFieldHandler("mounts/$mountName/audience"),
+                AuroraConfigFieldHandler("mounts/$mountName/expiration")
             )
         }.toSet()
     }
@@ -216,13 +221,17 @@ class MountFeature(
             val mountName: String = auroraDeploymentSpec["mounts/$mount/mountName"]
             val volumeName: String = auroraDeploymentSpec["mounts/$mount/volumeName"]
             val exist: Boolean = auroraDeploymentSpec["mounts/$mount/exist"]
+            val audience = auroraDeploymentSpec.getOrNull<String?>("mounts/$mount/audience")
+            val expiration = auroraDeploymentSpec.getOrNull<Long?>("mounts/$mount/expiration")
             Mount(
                 path = auroraDeploymentSpec["mounts/$mount/path"],
                 type = type,
                 mountName = mountName.ensureEndsWith("mount", "-"),
                 volumeName = if (exist) volumeName else volumeName.ensureEndsWith("mount", "-"),
                 exist = exist,
-                secretVaultName = secretVaultName
+                secretVaultName = secretVaultName,
+                audience = audience,
+                expiration = expiration
             )
         }
     }
@@ -249,6 +258,15 @@ fun List<Mount>.podVolumes(appName: String): List<Volume> {
                 MountType.PVC -> persistentVolumeClaim {
                     claimName = volumeName
                 }
+                MountType.PSAT -> {
+                    projected {
+                        name = volumeName
+                        defaultMode = 420
+                        sources = listOf(newVolumeProjection {
+                            serviceAccountToken = ServiceAccountTokenProjection(it.audience, it.expiration, "psat")
+                        })
+                    }
+                }
             }
         }
     }
@@ -256,7 +274,8 @@ fun List<Mount>.podVolumes(appName: String): List<Volume> {
 
 enum class MountType(val kind: String) {
     Secret("secret"),
-    PVC("persistentvolumeclaim")
+    PVC("persistentvolumeclaim"),
+    PSAT("projectedserviceaccounttoken")
 }
 
 data class Mount(
@@ -266,7 +285,9 @@ data class Mount(
     val volumeName: String,
     val exist: Boolean,
     val secretVaultName: String? = null,
-    val targetContainer: String? = null
+    val targetContainer: String? = null,
+    val audience: String? = null,
+    val expiration: Long? = null
 ) {
     fun getNamespacedVolumeName(appName: String): String {
         val name = if (exist) {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftClient.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/OpenShiftClient.kt
@@ -180,6 +180,14 @@ class OpenShiftClient(
         return OpenShiftGroups(groups)
     }
 
+    fun version(): String {
+        serviceAccountClient.get("/version", retry = false)?.body?.let {
+            val version = it.at("/gitVersion").textValue()
+            return version.substring(1, version.indexOf("+"))
+        }
+        throw java.lang.IllegalStateException("Unable to determine kubernetes version")
+    }
+
     fun resourceExists(kind: String, namespace: String, name: String): Boolean {
         val response = getClientForKind(kind).get(kind, namespace, name, false)
         return response?.statusCode?.is2xxSuccessful ?: false

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
@@ -85,7 +85,7 @@ class MountFeatureTest : AbstractFeatureTest() {
                   "type": "PSAT",
                   "path": "/u01/foo",
                   "audience": "dummy-audience",
-                  "expiration": 120,
+                  "expirationSeconds": 120,
                   "exist" : true
                 }
               }  

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
@@ -87,8 +87,7 @@ class MountFeatureTest : AbstractFeatureTest() {
                   "type": "PSAT",
                   "path": "/u01/foo",
                   "audience": "dummy-audience",
-                  "expirationSeconds": 600,
-                  "exist" : true
+                  "expirationSeconds": 600
                 }
               }  
              }"""
@@ -215,7 +214,6 @@ class MountFeatureTest : AbstractFeatureTest() {
 
     @Test
     fun `should modify deploymentConfig and add psat`() {
-        every { openShiftClient.resourceExists("projectedserviceaccounttoken", "paas-utv", "mount") } returns true
         every { openShiftClient.version() } returns "1.18.3"
 
         val resource = modifyResources(existingPSATJson, createEmptyDeploymentConfig())
@@ -232,7 +230,6 @@ class MountFeatureTest : AbstractFeatureTest() {
 
     @Test
     fun `psat is not supported in old k8s`() {
-        every { openShiftClient.resourceExists("projectedserviceaccounttoken", "paas-utv", "mount") } returns true
         every { openShiftClient.version() } returns "1.11.4"
 
         val exception = Assertions.assertThrows(MultiApplicationValidationException::class.java) {
@@ -252,7 +249,6 @@ class MountFeatureTest : AbstractFeatureTest() {
      */
     @Test
     fun `should not allow expirationSeconds less than 10 minutes`() {
-        every { openShiftClient.resourceExists("projectedserviceaccounttoken", "paas-utv", "mount") } returns true
         val exception = Assertions.assertThrows(MultiApplicationValidationException::class.java) {
             modifyResources(
                 """{
@@ -262,7 +258,6 @@ class MountFeatureTest : AbstractFeatureTest() {
                   "path": "/u01/foo",
                   "audience": "dummy-audience",
                   "expirationSeconds": 599,
-                  "exist" : true
                 }
               }  
              }""", createEmptyDeploymentConfig()

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
@@ -215,8 +215,8 @@ class MountFeatureTest : AbstractFeatureTest() {
 
     @Test
     fun `should modify deploymentConfig and add psat`() {
-
         every { openShiftClient.resourceExists("projectedserviceaccounttoken", "paas-utv", "mount") } returns true
+        every { openShiftClient.version() } returns "1.18.3"
 
         val resource = modifyResources(existingPSATJson, createEmptyDeploymentConfig())
 
@@ -228,6 +228,21 @@ class MountFeatureTest : AbstractFeatureTest() {
 
         assertThat(auroraResource).auroraResourceMountsPsat(psat)
         assertThat(auroraResource).auroraResourceMatchesFile("dc-with-psat.json")
+    }
+
+    @Test
+    fun `psat is not supported in old k8s`() {
+        every { openShiftClient.resourceExists("projectedserviceaccounttoken", "paas-utv", "mount") } returns true
+        every { openShiftClient.version() } returns "1.11.4"
+
+        val exception = Assertions.assertThrows(MultiApplicationValidationException::class.java) {
+            modifyResources(existingPSATJson, createEmptyDeploymentConfig())
+        }
+        Assertions.assertEquals(
+            1,
+            exception.errors.size,
+            "Expecting exactly one exception, but got: " + exception.errors
+        )
     }
 
     /**

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftClientTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftClientTest.kt
@@ -11,6 +11,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import junit.framework.TestCase.assertEquals
 import no.skatteetaten.aurora.boober.service.OpenShiftException
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResourceClient
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.OK
 import org.springframework.http.ResponseEntity
@@ -210,5 +212,14 @@ class OpenShiftClientTest : ResourceLoader() {
 
         assertThat(result.success).isFalse()
         assertThat(result.responseBody?.get("error")?.asText()).isEqualTo("failed")
+    }
+
+    @Test
+    fun `Should be able to call version endpoint`() {
+        val response = loadJsonResource("response_version.json")
+        every { serviceAccountClient.get("/version", any(), retry = any()) } returns ResponseEntity(response, OK)
+        every { serviceAccountClient.getAuthorizationHeaders() } returns HttpHeaders()
+        val result = openShiftClient.version()
+        assertEquals("1.18.3", result)
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/utils/AbstractFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/utils/AbstractFeatureTest.kt
@@ -429,9 +429,8 @@ abstract class AbstractFeatureTest : ResourceLoader() {
         val expectedEnv = additionalEnv.addIfNotNull(volumeEnvName to volumeEnvValue)
 
         assertThat(volumeName).isEqualTo(podSpec.containers[0].volumeMounts[0].name)
-        assertThat("dummy-audience").isEqualTo(projection.serviceAccountToken.audience)
-        // TODO FIX
         assertThat(podSpec.volumes[0].projected.sources[0].serviceAccountToken.audience).isEqualTo(projection.serviceAccountToken.audience)
+
         val env: Map<String, String> = podSpec.containers[0].env.associate { it.name to it.value }
         assertThat(env, "Env vars").isEqualTo(expectedEnv)
         actual

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/utils/AbstractFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/utils/AbstractFeatureTest.kt
@@ -29,6 +29,7 @@ import com.fkorotkov.openshift.template
 import com.fkorotkov.openshift.to
 import io.fabric8.kubernetes.api.model.HasMetadata
 import io.fabric8.kubernetes.api.model.IntOrString
+import io.fabric8.kubernetes.api.model.VolumeProjection
 import io.fabric8.openshift.api.model.DeploymentConfig
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -405,6 +406,32 @@ abstract class AbstractFeatureTest : ResourceLoader() {
                 attachment.metadata.name
             )
         }
+        val env: Map<String, String> = podSpec.containers[0].env.associate { it.name to it.value }
+        assertThat(env, "Env vars").isEqualTo(expectedEnv)
+        actual
+    }
+
+    fun Assert<AuroraResource>.auroraResourceMountsPsat(
+        projection: VolumeProjection,
+        additionalEnv: Map<String, String> = emptyMap()
+    ): Assert<AuroraResource> = transform { actual ->
+
+        assertThat(actual.resource).isInstanceOf(DeploymentConfig::class.java)
+        assertThat(actual).auroraResourceModifiedByThisFeatureWithComment("Added env vars, volume mount, volume")
+
+        val dc = actual.resource as DeploymentConfig
+        val podSpec = dc.spec.template.spec
+
+        val volumeName = podSpec.volumes[0].name
+        val volumeEnvName = "VOLUME_$volumeName".replace("-", "_").toUpperCase()
+        val volumeEnvValue = podSpec.containers[0].volumeMounts[0].mountPath
+
+        val expectedEnv = additionalEnv.addIfNotNull(volumeEnvName to volumeEnvValue)
+
+        assertThat(volumeName).isEqualTo(podSpec.containers[0].volumeMounts[0].name)
+        assertThat("dummy-audience").isEqualTo(projection.serviceAccountToken.audience)
+        // TODO FIX
+        assertThat(podSpec.volumes[0].projected.sources[0].serviceAccountToken.audience).isEqualTo(projection.serviceAccountToken.audience)
         val env: Map<String, String> = podSpec.containers[0].env.associate { it.name to it.value }
         assertThat(env, "Env vars").isEqualTo(expectedEnv)
         actual

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-psat.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-psat.json
@@ -50,7 +50,7 @@
                 {
                   "serviceAccountToken": {
                     "audience": "dummy-audience",
-                    "expirationSeconds": 120,
+                    "expirationSeconds": 600,
                     "path": "mount"
                   }
                 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-psat.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-psat.json
@@ -51,7 +51,7 @@
                   "serviceAccountToken": {
                     "audience": "dummy-audience",
                     "expirationSeconds": 120,
-                    "path": "psat"
+                    "path": "mount"
                   }
                 }
               ]

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-psat.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-psat.json
@@ -1,0 +1,79 @@
+{
+  "apiVersion": "apps.openshift.io/v1",
+  "kind": "DeploymentConfig",
+  "metadata": {
+    "name": "simple",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "name": "simple"
+    },
+    "strategy": {
+      "rollingParams": {
+        "intervalSeconds": 1,
+        "maxSurge": "25%",
+        "maxUnavailable": 0,
+        "timeoutSeconds": 180,
+        "updatePeriodSeconds": 1
+      },
+      "type": "Rolling"
+    },
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "VOLUME_MOUNT",
+                "value": "/u01/foo"
+              }
+            ],
+            "name": "simple",
+            "volumeMounts": [
+              {
+                "mountPath": "/u01/foo",
+                "name": "mount"
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always",
+        "volumes": [
+          {
+            "name": "mount",
+            "projected": {
+              "defaultMode": 420,
+              "sources": [
+                {
+                  "serviceAccountToken": {
+                    "audience": "dummy-audience",
+                    "expirationSeconds": 120,
+                    "path": "psat"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "triggers": [
+      {
+        "imageChangeParams": {
+          "automatic": true,
+          "containerNames": [
+            "simple"
+          ],
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "simple:default"
+          }
+        },
+        "type": "ImageChange"
+      }
+    ]
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/unit/OpenShiftClientTest/response_version.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/unit/OpenShiftClientTest/response_version.json
@@ -1,0 +1,11 @@
+{
+  "major": "1",
+  "minor": "18+",
+  "gitVersion": "v1.18.3+65bd32d",
+  "gitCommit": "65bd32d",
+  "gitTreeState": "clean",
+  "buildDate": "2021-01-27T04:24:26Z",
+  "goVersion": "go1.13.15",
+  "compiler": "gc",
+  "platform": "linux/amd64"
+}


### PR DESCRIPTION
Details of PSAT setup:
https://access.redhat.com/documentation/en-us/openshift_container_platform/4.6/html/authentication_and_authorization/bound-service-account-tokens 

This PR makes a new mount type - `PSAT` - and adds relevant properties for it:
```
mounts/<mountName>/audience
mounts/<mountName>/expiration
```
