### PR TITLE
Bugfix/aos 5472 sletting av et vault f rte til sletting av alle vaults i et repo

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/GitService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/GitService.kt
@@ -135,9 +135,14 @@ open class GitService(
         }
     }
 
-    fun commitAndPushChanges(repo: Git, ref: String = "refs/heads/master", commitMessage: String? = null) {
+    fun commitAndPushChanges(repo: Git, ref: String = "refs/heads/master", commitMessage: String? = null, addFilePattern: String? = ".", rmFilePattern: String? = null) {
 
-        repo.add().addFilepattern(".").call()
+        if (addFilePattern != null) {
+            repo.add().addFilepattern(addFilePattern).call()
+        }
+        if (rmFilePattern != null) {
+            repo.rm().addFilepattern(rmFilePattern).call()
+        }
         val status = repo.status().call()
         val message = commitMessage
             ?: "Added: ${status.added.size}, Modified: ${status.changed.size}, Deleted: ${status.removed.size}"

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/GitService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/GitService.kt
@@ -135,7 +135,17 @@ open class GitService(
         }
     }
 
-    fun commitAndPushChanges(repo: Git, ref: String = "refs/heads/master", commitMessage: String? = null, addFilePattern: String? = ".", rmFilePattern: String? = null) {
+    /**
+     * When using addFilePattern or rmFilePattern there might be some changes that will not be committed.
+     * For removing unwanted changes use [cleanUpUnstagedCommits].
+     */
+    fun commitAndPushChanges(
+        repo: Git,
+        ref: String = "refs/heads/master",
+        commitMessage: String? = null,
+        addFilePattern: String? = ".",
+        rmFilePattern: String? = null
+    ) {
 
         if (addFilePattern != null) {
             repo.add().addFilepattern(addFilePattern).call()
@@ -164,6 +174,22 @@ open class GitService(
         } catch (e: Exception) {
             throw e
         }
+    }
+
+    /**
+     * This should be used to prevent unwanted changes being committed.
+     * @return true if clean up was successfully, false if not.
+     */
+    fun cleanUpUnstagedCommits(git: Git): Boolean {
+        val status = git.status().call()
+        if (status.isClean) {
+            return true
+        }
+
+        git.checkout().addPath(".").call()
+        val statusAfterCheckout = git.status().call()
+
+        return statusAfterCheckout.isClean
     }
 
     fun getTagHistory(git: Git): List<RevTag> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/EncryptedFileVault.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/EncryptedFileVault.kt
@@ -42,11 +42,6 @@ class VaultCollection private constructor(
         return EncryptedFileVault.createFromFolder(vaultFolder, encryptor, decryptor)
     }
 
-    fun deleteVault(vaultName: String) {
-
-        File(folder, vaultName).deleteRecursively()
-    }
-
     private fun findAllVaultFolders(): List<File> {
 
         return folder.listFiles()

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/VaultService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/VaultService.kt
@@ -109,10 +109,14 @@ class VaultService(
 
     fun deleteVault(vaultCollectionName: String, vaultName: String) {
         return withVaultCollectionAndRepoForUpdate(vaultCollectionName) { vaultCollection, repo ->
-            findVaultByNameIfAllowed(vaultCollection, vaultName) ?: return@withVaultCollectionAndRepoForUpdate
+            if (vaultName.isBlank()) {
+                throw IllegalArgumentException("Vault name can not be empty")
+            }
 
-            vaultCollection.deleteVault(vaultName)
-            gitService.commitAndPushChanges(repo)
+            val vault = findVaultByNameIfAllowed(vaultCollection, vaultName) ?: return@withVaultCollectionAndRepoForUpdate
+
+            vault.vaultFolder.deleteRecursively()
+            gitService.commitAndPushChanges(repo = repo, rmFilePattern = vault.vaultFolder.name, addFilePattern = null)
         }
     }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/VaultService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/VaultService.kt
@@ -121,9 +121,9 @@ class VaultService(
 
             vault.vaultFolder.deleteRecursively()
             gitService.commitAndPushChanges(repo = repo, rmFilePattern = vault.vaultFolder.name, addFilePattern = null)
-            val isClean = gitService.cleanUpUnstagedCommits(repo)
+            val isClean = gitService.cleanRepo(repo)
             if (!isClean) {
-                logger.warn("could not clean up unstaged commits")
+                logger.warn("could not clean repository")
             }
         }
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/VaultService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/vault/VaultService.kt
@@ -111,11 +111,11 @@ class VaultService(
     }
 
     fun deleteVault(vaultCollectionName: String, vaultName: String) {
-        return withVaultCollectionAndRepoForUpdate(vaultCollectionName) { vaultCollection, repo ->
-            if (vaultName.isBlank()) {
-                throw IllegalArgumentException("vault name can not be empty")
-            }
+        if (vaultName.isBlank()) {
+            throw IllegalArgumentException("vault name can not be empty")
+        }
 
+        return withVaultCollectionAndRepoForUpdate(vaultCollectionName) { vaultCollection, repo ->
             val vault =
                 findVaultByNameIfAllowed(vaultCollection, vaultName) ?: return@withVaultCollectionAndRepoForUpdate
 

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/VaultServiceTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/VaultServiceTest.kt
@@ -13,6 +13,7 @@ import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isSuccess
 import assertk.assertions.isTrue
+import assertk.assertions.messageContains
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -20,7 +21,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import no.skatteetaten.aurora.AuroraMetrics
 import no.skatteetaten.aurora.boober.controller.security.User
-import no.skatteetaten.aurora.boober.service.AuroraVaultServiceException
 import no.skatteetaten.aurora.boober.service.EncryptionService
 import no.skatteetaten.aurora.boober.service.GitService
 import no.skatteetaten.aurora.boober.service.UnauthorizedAccessException
@@ -214,8 +214,8 @@ class VaultServiceTest {
         assertThat {
             vaultService.deleteVault(COLLECTION_NAME, "")
         }.isFailure().all {
-            isInstanceOf(AuroraVaultServiceException::class)
-            hasMessage("Could not update auroraVault underlying message=vault name can not be empty")
+            isInstanceOf(IllegalArgumentException::class)
+            messageContains("vault name can not be empty")
         }
     }
 


### PR DESCRIPTION
Forsøk på å begrense sletting til ett vault.

TLDR;
1. Utføre sletting på vaultFolder fra vaultet som blir hentet fremfor å bruke vaultName som parameter til File for sletting.
2. Legger til to nye parametere på commitAndPush funksjonenen for å begrense hvilke mapper/filer som blir med i committen.
3. Fjerne evt uønskede endringer i repoet etter commitAndPush.