### PR TITLE
AOT-1253 Only support auroracname on ocp4

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
@@ -156,20 +156,8 @@ class MountFeature(
             .addIfNotNull(validateVaultExistence(mounts, adc))
     }
 
-    /**
-     * @return true if given semver version is found to be higher or equal to kubernetes semver version
-     */
-    private fun k8sVersionOfAtLeast(ensure: String): Boolean {
-        val k8s = openShiftClient.version().split(".")
-        val v = ensure.split(".")
-        for (index in 0 until Math.min(k8s.size, v.size)) {
-            if (k8s[index].toInt() < v[index].toInt()) return false
-        }
-        return true
-    }
-
     private fun ensureCompatibleKuberntesForPSATMounts(mounts: List<Mount>): List<Exception> {
-        return mounts.filter() { it.type == MountType.PSAT && !k8sVersionOfAtLeast("1.16") }.map {
+        return mounts.filter() { it.type == MountType.PSAT && !openShiftClient.k8sVersionOfAtLeast("1.16") }.map {
             AuroraDeploymentSpecValidationException("PSAT mount=${it.volumeName} is not valid, as kubernetes version is below 1.16")
         }
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftCommandService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftCommandService.kt
@@ -184,6 +184,7 @@ class OpenShiftCommandService(
 
         val labelSelectors = listOf("app=$name", "booberDeployId", "booberDeployId!=$deployId")
         return apiResources
+            .filter { kind -> !kind.toLowerCase().equals("auroracname") || openShiftClient.k8sVersionOfAtLeast("1.16") }
             .flatMap { kind -> openShiftClient.getByLabelSelectors(kind, namespace, labelSelectors) }
             .map {
                 try {

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/facade/DeployFacadeTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/facade/DeployFacadeTest.kt
@@ -109,6 +109,10 @@ class DeployFacadeTest(@Value("\${application.deployment.id}") val booberAdId: S
                 mockJsonFromFile("groups.json")
             }
 
+            rule({ path?.endsWith("/version") }) {
+                mockJsonFromFile("response_version.json")
+            }
+
             // Should it be able to reuse rules?
             rule(mockOpenShiftUsers)
 
@@ -213,6 +217,10 @@ class DeployFacadeTest(@Value("\${application.deployment.id}") val booberAdId: S
 
             rule({ path?.endsWith("/groups") }) {
                 mockJsonFromFile("groups.json")
+            }
+
+            rule({ path?.endsWith("/version") }) {
+                mockJsonFromFile("response_version.json")
             }
 
             // Should it be able to reuse rules?

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
@@ -214,7 +214,7 @@ class MountFeatureTest : AbstractFeatureTest() {
 
     @Test
     fun `should modify deploymentConfig and add psat`() {
-        every { openShiftClient.version() } returns "1.18.3"
+        every { openShiftClient.k8sVersionOfAtLeast("1.16") } returns true
 
         val resource = modifyResources(existingPSATJson, createEmptyDeploymentConfig())
 

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftClientTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftClientTest.kt
@@ -11,7 +11,6 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import junit.framework.TestCase.assertEquals
 import no.skatteetaten.aurora.boober.service.OpenShiftException
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftClient
 import no.skatteetaten.aurora.boober.service.openshift.OpenShiftResourceClient
@@ -19,6 +18,9 @@ import no.skatteetaten.aurora.boober.service.openshift.OpenshiftCommand
 import no.skatteetaten.aurora.boober.service.openshift.OperationType
 import no.skatteetaten.aurora.boober.utils.ResourceLoader
 import no.skatteetaten.aurora.boober.utils.jsonMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -221,5 +223,9 @@ class OpenShiftClientTest : ResourceLoader() {
         every { serviceAccountClient.getAuthorizationHeaders() } returns HttpHeaders()
         val result = openShiftClient.version()
         assertEquals("1.18.3", result)
+        assertTrue(openShiftClient.k8sVersionOfAtLeast("1.16"))
+        assertTrue(openShiftClient.k8sVersionOfAtLeast("1.18.3"))
+        assertFalse(openShiftClient.k8sVersionOfAtLeast("1.19"))
+        assertFalse(openShiftClient.k8sVersionOfAtLeast("1.18.4"))
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftCommandServiceCreateDeleteCommandsTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftCommandServiceCreateDeleteCommandsTest.kt
@@ -43,6 +43,10 @@ class OpenShiftCommandServiceCreateDeleteCommandsTest : ResourceLoader() {
         } returns HttpHeaders()
 
         every {
+            saClient.get("/version", retry = false)
+        } returns ResponseEntity.ok(loadJsonResource("response_version.json"))
+
+        every {
             userClient.getAuthorizationHeaders()
         } returns HttpHeaders()
         Instants.determineNow = { Instant.EPOCH }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/response_version.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/response_version.json
@@ -1,0 +1,11 @@
+{
+  "major": "1",
+  "minor": "18+",
+  "gitVersion": "v1.18.3+65bd32d",
+  "gitCommit": "65bd32d",
+  "gitTreeState": "clean",
+  "buildDate": "2021-01-27T04:24:26Z",
+  "goVersion": "go1.13.15",
+  "compiler": "gc",
+  "platform": "linux/amd64"
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/unit/OpenShiftCommandServiceCreateDeleteCommandsTest/response_version.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/unit/OpenShiftCommandServiceCreateDeleteCommandsTest/response_version.json
@@ -1,0 +1,11 @@
+{
+  "major": "1",
+  "minor": "18+",
+  "gitVersion": "v1.18.3+65bd32d",
+  "gitCommit": "65bd32d",
+  "gitTreeState": "clean",
+  "buildDate": "2021-01-27T04:24:26Z",
+  "goVersion": "go1.13.15",
+  "compiler": "gc",
+  "platform": "linux/amd64"
+}


### PR DESCRIPTION
Two things that this PR addresses:
- AuroraCname only considered for OCP4 deployment
- Run queries for auroracname with the service account boober runs as, not as the user