### PR TITLE
feature/AOT-1260 retain annotations for cname

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
     id("org.sonarqube") version "2.8"
 
-    id("org.springframework.boot") version "2.2.6.RELEASE"
+    id("org.springframework.boot") version "2.2.13.RELEASE"
     id("org.asciidoctor.convert") version "2.4.0"
 
     id("com.gorylenko.gradle-git-properties") version "2.2.2"
@@ -42,7 +42,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.retry:spring-retry")
-    implementation("com.cronutils:cron-utils:9.0.2")
+    implementation("com.cronutils:cron-utils:9.1.5")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://nexus.sits.no/repository/gradle-distributions/gradle-6.2-bin.zip
+distributionUrl=https\://nexus.sits.no/repository/gradle-distributions/gradle-6.8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/ResourceMerger.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/ResourceMerger.kt
@@ -27,6 +27,7 @@ fun mergeWithExistingResource(newResource: JsonNode, existingResource: JsonNode)
         "deploymentconfig" -> updateDeploymentConfig(mergedResource, existingResource)
         "buildconfig" -> updateBuildConfig(mergedResource, existingResource)
         "namespace" -> updateNamespace(mergedResource, existingResource)
+        "auroracname" -> updateAuroraCname(mergedResource, existingResource)
     }
     return mergedResource
 }
@@ -55,4 +56,7 @@ private fun updateService(mergedResource: JsonNode, existingResource: JsonNode) 
 }
 
 private fun updateNamespace(mergedResource: ObjectNode, existingResource: ObjectNode) =
+    mergedResource.mergeField(existingResource, "/metadata", "annotations")
+
+private fun updateAuroraCname(mergedResource: ObjectNode, existingResource: ObjectNode) =
     mergedResource.mergeField(existingResource, "/metadata", "annotations")

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
@@ -24,7 +24,8 @@ class ResourceMergerTest : ResourceLoader() {
             )
         ),
         CONFIGMAP(listOf("/metadata/resourceVersion")),
-        NAMESPACE(listOf("/metadata/annotations"))
+        NAMESPACE(listOf("/metadata/annotations")),
+        AURORACNAME(listOf("/metadata/annotations")),
     }
 
     @ParameterizedTest

--- a/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/auroracname-new.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/auroracname-new.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "skatteetaten.no/v1",
+  "kind": "AuroraCname",
+  "metadata": {
+    "labels": {
+      "affiliation": "demo",
+      "app": "cname-demo"
+    },
+    "name": "cname-demo",
+    "namespace": "demo-psat-poc"
+  },
+  "spec": {
+    "cname": "gavel-poc-10.cname-poc10.utv.paas.skead.no",
+    "host": "apps.utv04.paas.skead.no",
+    "ttl": 300
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/auroracname.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/auroracname.json
@@ -1,0 +1,20 @@
+{
+  "apiVersion": "skatteetaten.no/v1",
+  "kind": "AuroraCname",
+  "metadata": {
+    "annotations": {
+      "judge.sits.no/notified": "true"
+    },
+    "labels": {
+      "affiliation": "demo",
+      "app": "cname-demo"
+    },
+    "name": "cname-demo",
+    "namespace": "demo-psat-poc"
+  },
+  "spec": {
+    "cname": "gavel-poc-10.cname-poc10.utv.paas.skead.no",
+    "host": "apps.utv04.paas.skead.no",
+    "ttl": 300
+  }
+}


### PR DESCRIPTION
Ved redeploy av eksisterende applikasjon, ville AuroraCname bli strippet av sine annoteringer. Det gjorde at AOT-1246 ikke kunne bli løst på en tilfredsstillende måte. Med denne PRen beholdes annoteringene.

Jeg oppdaterte også versjon av avhengighetene spring-boot og cron-utils.