### PR TITLE
SITJ-1249 Support several PSAT audiences

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
@@ -32,7 +32,6 @@ import no.skatteetaten.aurora.boober.utils.required
 import org.apache.commons.codec.binary.Base64
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
-import kotlin.streams.toList
 
 private const val MOUNTS_CONTEXT_KEY = "mounts"
 
@@ -287,19 +286,11 @@ fun List<Mount>.podVolumes(appName: String): List<Volume> {
 }
 
 private fun createPsatSources(psat: Mount): List<VolumeProjection> {
-    return if (psat.audience == null) {
-        emptyList()
-    } else {
-        psat.audience
-            .split(",")
-            .stream()
-            .map { aud ->
-                newVolumeProjection {
-                    serviceAccountToken = ServiceAccountTokenProjection(aud, psat.expirationSeconds, aud)
-                }
-            }
-            .toList()
-    }
+    return psat.audience?.split(",")?.map { aud ->
+        newVolumeProjection {
+            serviceAccountToken = ServiceAccountTokenProjection(aud, psat.expirationSeconds, aud)
+        }
+    }?.toList() ?: emptyList()
 }
 
 enum class MountType(val kind: String) {

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/MountFeatureTest.kt
@@ -269,4 +269,26 @@ class MountFeatureTest : AbstractFeatureTest() {
             "Expecting exactly one exception, but got: " + exception.errors
         )
     }
+
+    @Test
+    fun `should allow comma separated audience list`() {
+        every { openShiftClient.k8sVersionOfAtLeast("1.16") } returns true
+
+        val resource = modifyResources(
+            """{
+              "mounts": {
+                "mount": {
+                  "type": "PSAT",
+                  "path": "/u01/foo",
+                  "audience": "first,second,third",
+                  "expirationSeconds": 600
+                }
+              }  
+             }""", createEmptyDeploymentConfig()
+        )
+        // ,second,third
+        val auroraResource = resource.first()
+
+        assertThat(auroraResource).auroraResourceMatchesFile("dc-with-several-psats.json")
+    }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-several-psats.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/MountFeatureTest/dc-with-several-psats.json
@@ -49,9 +49,23 @@
               "sources": [
                 {
                   "serviceAccountToken": {
-                    "audience": "dummy-audience",
+                    "audience": "first",
                     "expirationSeconds": 600,
-                    "path": "dummy-audience"
+                    "path": "first"
+                  }
+                },
+                {
+                  "serviceAccountToken": {
+                    "audience": "second",
+                    "expirationSeconds": 600,
+                    "path": "second"
+                  }
+                },
+                {
+                  "serviceAccountToken": {
+                    "audience": "third",
+                    "expirationSeconds": 600,
+                    "path": "third"
                   }
                 }
               ]


### PR DESCRIPTION
We want to support more than just 1 audience for PSAT. The kuberentes volume projection of `serviceAccountToken` supports only 1 audience. However, there is possible to have have a list of `serviceAccountToken` _sources_. I.e. one PSAT for each audience. This suits us fine, and is just an implementation detail for the client applications.

In the boober configuration, I find it natural to support a comma-separated list of audiences, as opposed to an array of audiences. 

A change in usage is that the mounted PSAT will have the name of the audience. 