### PR TITLE
SITJ-1301 Fix problem with merging when source is missing

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -141,9 +141,11 @@ fun JsonNode.updateField(source: JsonNode, root: String, field: String, required
 
 fun JsonNode.mergeField(source: ObjectNode, root: String, field: String) {
     val jsonPtrExpr = "$root/$field"
-    val sourceObject = source.at(jsonPtrExpr) as ObjectNode
-
-    val mergedObject = sourceObject.deepCopy()
+    val sourceObject = source.at(jsonPtrExpr)
+    if (sourceObject.isMissingNode) {
+        return
+    }
+    val mergedObject = (sourceObject as ObjectNode).deepCopy()
 
     val fieldNode = this.at(jsonPtrExpr)
     if (fieldNode is ObjectNode) {

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
@@ -40,4 +40,16 @@ class ResourceMergerTest : ResourceLoader() {
             assertThat(merged.at(it)).isEqualTo(oldResource.at(it))
         }
     }
+
+    @ParameterizedTest
+    @EnumSource(OpenShiftResourceTypeTestData::class)
+    fun `Should accept that element to retain might be missing for `(test: OpenShiftResourceTypeTestData) {
+        val type = test.name.toLowerCase()
+        val oldResource = loadJsonResource("$type-new.json")
+        val newResource = loadJsonResource("$type-new.json")
+        val merged = mergeWithExistingResource(newResource, oldResource)
+        test.fields.forEach {
+            assertThat(merged.at(it)).isEqualTo(oldResource.at(it))
+        }
+    }
 }


### PR DESCRIPTION
Ved deployment av utvalgte objekttyper, blant annet AuroraCname, blir annotations kopiert til det nye objektet for å beholde verdier. Det har blitt avdekket et problem dersom source i	kopieringen ikke finnes: Da får man en	MissiningNode fra Jackson, som så gir en ClassCastException.