### PR TITLE
AOT-706 Validation error if invalid dns entry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,8 @@ dependencies {
     // The above library uses an vulnerable bcprov, set the fixed version here, hopefully this will work.
     // pr is sent to maintainer
     implementation("org.bouncycastle:bcprov-jdk15on:1.65")
-    implementation("com.github.ben-manes.caffeine:caffeine:2.8.1")
-    implementation("org.apache.commons:commons-text:1.8")
+    implementation("com.github.ben-manes.caffeine:caffeine:3.0.2")
+    implementation("org.apache.commons:commons-text:1.9")
 
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
 
@@ -47,10 +47,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
 
-    testImplementation("io.mockk:mockk:1.10.0")
+    testImplementation("io.mockk:mockk:1.11.0")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.20")
     testImplementation("no.skatteetaten.aurora:mockmvc-extensions-kotlin:1.1.0")
-    testImplementation("com.ninja-squad:springmockk:2.0.1")
+    testImplementation("com.ninja-squad:springmockk:2.0.3")
 }
 
 testlogger {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/RouteFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/RouteFeature.kt
@@ -29,8 +29,10 @@ import no.skatteetaten.aurora.boober.utils.addIfNotNull
 import no.skatteetaten.aurora.boober.utils.boolean
 import no.skatteetaten.aurora.boober.utils.ensureStartWith
 import no.skatteetaten.aurora.boober.utils.int
+import no.skatteetaten.aurora.boober.utils.isValidDns
 import no.skatteetaten.aurora.boober.utils.oneOf
 import no.skatteetaten.aurora.boober.utils.startsWith
+import no.skatteetaten.aurora.boober.utils.validDnsPreExpansion
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 
@@ -66,7 +68,8 @@ class RouteFeature(@Value("\${boober.route.suffix}") val routeSuffix: String) : 
             ),
             AuroraConfigFieldHandler(
                 "routeDefaults/host",
-                defaultValue = "@name@-@affiliation@-@env@"
+                defaultValue = "@name@-@affiliation@-@env@",
+                validator = { it.validDnsPreExpansion() }
             ),
             AuroraConfigFieldHandler(
                 "routeDefaults/tls/enabled",
@@ -241,7 +244,10 @@ class RouteFeature(@Value("\${boober.route.suffix}") val routeSuffix: String) : 
                     "$key/cname/ttl",
                     validator = { it.int(false) }
                 ),
-                AuroraConfigFieldHandler("$key/host"),
+                AuroraConfigFieldHandler(
+                    "$key/host",
+                    validator = { it.validDnsPreExpansion() }
+                ),
                 AuroraConfigFieldHandler(
                     "$key/fullyQualifiedHost",
                     validator = { it.boolean(false) }), // since this is internal I do not want default value on it.
@@ -315,7 +321,19 @@ class RouteFeature(@Value("\${boober.route.suffix}") val routeSuffix: String) : 
             )
         } else null
 
+        val checkDns = routes
+            .filter { !it.host.isValidDns() }
+            .map {
+                AuroraConfigException(
+                    "Application ${applicationDeploymentRef.application} in environment ${applicationDeploymentRef.environment} has invalid dns name \"${it.host}\"",
+                    errors = cnameAndFqdnHost.map { route ->
+                        ConfigFieldErrorDetail.illegal(message = "host=${route.host} must be a valid dns entry.")
+                    }
+                )
+            }.firstOrNull()
+
         return tlsErrors
+            .addIfNotNull(checkDns)
             .addIfNotNull(duplicateRouteErrors)
             .addIfNotNull(duplicateHostError)
             .addIfNotNull(cnameAndFqdnHostSimultaneously)

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/RouteFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/RouteFeature.kt
@@ -69,7 +69,7 @@ class RouteFeature(@Value("\${boober.route.suffix}") val routeSuffix: String) : 
             AuroraConfigFieldHandler(
                 "routeDefaults/host",
                 defaultValue = "@name@-@affiliation@-@env@",
-                validator = { it.validDnsPreExpansion() }
+                validator = { it?.validDnsPreExpansion() }
             ),
             AuroraConfigFieldHandler(
                 "routeDefaults/tls/enabled",
@@ -246,7 +246,7 @@ class RouteFeature(@Value("\${boober.route.suffix}") val routeSuffix: String) : 
                 ),
                 AuroraConfigFieldHandler(
                     "$key/host",
-                    validator = { it.validDnsPreExpansion() }
+                    validator = { it?.validDnsPreExpansion() }
                 ),
                 AuroraConfigFieldHandler(
                     "$key/fullyQualifiedHost",
@@ -321,7 +321,7 @@ class RouteFeature(@Value("\${boober.route.suffix}") val routeSuffix: String) : 
             )
         } else null
 
-        val checkDns = routes
+        val dnsErrors = routes
             .filter { !it.host.isValidDns() }
             .map {
                 AuroraConfigException(
@@ -330,10 +330,10 @@ class RouteFeature(@Value("\${boober.route.suffix}") val routeSuffix: String) : 
                         ConfigFieldErrorDetail.illegal(message = "host=${route.host} must be a valid dns entry.")
                     }
                 )
-            }.firstOrNull()
+            }
 
         return tlsErrors
-            .addIfNotNull(checkDns)
+            .addIfNotNull(dnsErrors)
             .addIfNotNull(duplicateRouteErrors)
             .addIfNotNull(duplicateHostError)
             .addIfNotNull(cnameAndFqdnHostSimultaneously)

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/StringUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/StringUtils.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.apache.commons.io.FilenameUtils
 import org.springframework.util.Base64Utils
+import java.util.regex.Pattern
 
 fun String.ensureEndsWith(endsWith: String, seperator: String = ""): String {
     if (this.endsWith(endsWith)) {
@@ -23,6 +24,23 @@ fun String.ensureStartWith(startWith: String, seperator: String = ""): String {
         return this
     }
     return "$startWith$seperator$this"
+}
+
+/** Inspired by https://www.geeksforgeeks.org/how-to-validate-a-domain-name-using-regular-expression/
+ * but trimmed down due to local needs
+ */
+private val dnsMatcher: Pattern = Pattern.compile(
+    "^((?!-)[A-Za-z0-9-]" +
+            "{1,63}(?<!-))"
+)
+
+fun String.isValidDns(): Boolean {
+    this
+        .split(".")
+        .filter { !dnsMatcher.matcher(it).matches() }
+        .any { return false }
+
+    return this.length < 254
 }
 
 fun String.removeExtension(): String = FilenameUtils.removeExtension(this)

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/StringUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/StringUtils.kt
@@ -35,12 +35,9 @@ private val dnsMatcher: Pattern = Pattern.compile(
 )
 
 fun String.isValidDns(): Boolean {
-    this
+    return this
         .split(".")
-        .filter { !dnsMatcher.matcher(it).matches() }
-        .any { return false }
-
-    return this.length < 254
+        .all { dnsMatcher.matcher(it).matches() } && this.length < 254
 }
 
 fun String.removeExtension(): String = FilenameUtils.removeExtension(this)

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -237,13 +237,12 @@ fun JsonNode?.boolean(required: Boolean = false): Exception? {
 }
 
 fun JsonNode.validDnsPreExpansion(): Exception? {
-    this.textValue()
+    return this.textValue()
         .replace("@", "") // Must allow @ as substitution occurs after validation
         .split(".")
         .filter { !it.isValidDns() }
-        .any { return IllegalArgumentException("Invalid DNS node entry: \"${this.textValue()}\", disliked $it") }
-
-    return null
+        .map { IllegalArgumentException("Invalid DNS node entry: \"${this.textValue()}\", disliked $it") }
+        .firstOrNull()
 }
 
 fun JsonNode?.oneOf(candidates: List<String>, required: Boolean = true): Exception? {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -236,6 +236,20 @@ fun JsonNode?.boolean(required: Boolean = false): Exception? {
     return null
 }
 
+fun JsonNode?.validDnsPreExpansion(): Exception? {
+    if (this == null) {
+        return null
+    }
+
+    this.textValue()
+        .replace("@", "") // Must allow @ as substitution occurs after validation
+        .split(".")
+        .filter { !it.isValidDns() }
+        .any { return IllegalArgumentException("Invalid DNS node entry: \"${this.textValue()}\", disliked $it") }
+
+    return null
+}
+
 fun JsonNode?.oneOf(candidates: List<String>, required: Boolean = true): Exception? {
     if (this == null || !this.isTextual) {
         return if (required) {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/jsonNodeUtils.kt
@@ -236,11 +236,7 @@ fun JsonNode?.boolean(required: Boolean = false): Exception? {
     return null
 }
 
-fun JsonNode?.validDnsPreExpansion(): Exception? {
-    if (this == null) {
-        return null
-    }
-
+fun JsonNode.validDnsPreExpansion(): Exception? {
     this.textValue()
         .replace("@", "") // Must allow @ as substitution occurs after validation
         .split(".")

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/RouteFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/RouteFeatureTest.kt
@@ -13,7 +13,6 @@ import no.skatteetaten.aurora.boober.model.AuroraResource
 import no.skatteetaten.aurora.boober.service.MultiApplicationValidationException
 import no.skatteetaten.aurora.boober.utils.AbstractFeatureTest
 import no.skatteetaten.aurora.boober.utils.singleApplicationError
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -673,7 +672,7 @@ class RouteFeatureTest : AbstractFeatureTest() {
 
     @Test
     fun `a dns host name cannot be more than 253 chars`() {
-        val ex: MultiApplicationValidationException = assertThrows {
+        assertThat {
             generateResources(
                 """
                 {
@@ -688,8 +687,7 @@ class RouteFeatureTest : AbstractFeatureTest() {
                 createEmptyDeploymentConfig(),
                 createdResources = 1
             )
-        }
-        assertTrue(ex.message?.contains(("An error occurred")) ?: false, "Could not find text in ${ex.message}")
+        }.singleApplicationError("Invalid DNS node entry")
     }
 
     @Test
@@ -712,26 +710,25 @@ class RouteFeatureTest : AbstractFeatureTest() {
 
     @Test
     fun `a host name cannot exceed 63 chars`() {
-        val ex: MultiApplicationValidationException = assertThrows {
+        assertThat {
             generateResources(
                 """
                 {
                   "route" : {
                     "foo" : {
-                      "host": "X$sixtyThree""
+                      "host": "X$sixtyThree"
                     }
                   }
                 }
                 """.trimIndent(),
                 createEmptyDeploymentConfig()
             )
-        }
-        assertThat { ex.message?.contains("DNS node") }
+        }.singleApplicationError("Invalid DNS node entry")
     }
 
     @Test
     fun `when having cname, dns must be valid`() {
-        val ex: MultiApplicationValidationException = assertThrows {
+        assertThat {
             generateResources(
                 """
                 {
@@ -746,15 +743,14 @@ class RouteFeatureTest : AbstractFeatureTest() {
                   }
                 }
                 """.trimIndent(),
-                resource = createEmptyDeploymentConfig()
+                resource = createEmptyDeploymentConfig(), createdResources = 3
             )
-        }
-        assertThat { ex.message?.contains("DNS node") }
+        }.singleApplicationError("Invalid DNS node entry")
     }
 
     @Test
     fun `a node in a fqdn host statement cannot exceed 63 chars`() {
-        val ex: MultiApplicationValidationException = assertThrows {
+        assertThat {
             generateResources(
                 """
                 {
@@ -767,13 +763,12 @@ class RouteFeatureTest : AbstractFeatureTest() {
                 }
                 """.trimIndent(), createEmptyDeploymentConfig()
             )
-        }
-        assertThat { ex.message?.contains("DNS node") }
+        }.singleApplicationError("Invalid DNS node entry")
     }
 
     @Test
     fun `default host nodes cannot exceed 63 chars`() {
-        val ex: MultiApplicationValidationException = assertThrows {
+        assertThat {
             generateResources(
                 """
                 {
@@ -792,8 +787,7 @@ class RouteFeatureTest : AbstractFeatureTest() {
                 """.trimIndent(),
                 createEmptyDeploymentConfig()
             )
-        }
-        assertThat { ex.message?.contains("DNS node") }
+        }.singleApplicationError("Invalid DNS node entry")
     }
 
     @ParameterizedTest
@@ -812,7 +806,7 @@ class RouteFeatureTest : AbstractFeatureTest() {
     @ParameterizedTest
     @CsvSource(value = ["x_1.xx", "some.org-", "-some.org", ".no", "x.no.", "x..no"])
     fun `invalid host names should fail`(dns: String) {
-        val ex: MultiApplicationValidationException = assertThrows {
+        assertThat {
             generateResources(
                 """{"route" : {"foo" : {
                   "host": """" + dns + """", "cname" : { "enabled" : "true" }
@@ -820,7 +814,6 @@ class RouteFeatureTest : AbstractFeatureTest() {
                 createEmptyDeploymentConfig(),
                 createdResources = 2
             )
-        }
-        assertThat { ex.message?.contains("invalid dns name") }
+        }.singleApplicationError("Invalid DNS node entry")
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/utils/AbstractFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/utils/AbstractFeatureTest.kt
@@ -441,7 +441,7 @@ abstract class AbstractFeatureTest : ResourceLoader() {
         if (expected == actual.createdSource.feature) {
             actual
         } else {
-            expected(":${show(expected)} and:${show(actual.createdSource.feature)} to be the same")
+            this.expected(":${show(expected)} and:${show(actual.createdSource.feature)} to be the same")
         }
     }
 
@@ -452,7 +452,7 @@ abstract class AbstractFeatureTest : ResourceLoader() {
             if (actual == expected) {
                 ar
             } else {
-                expected(":${show(expected)} and:${show(actual)} to be the same")
+                this.expected(":${show(expected)} and:${show(actual)} to be the same")
             }
         }
 }


### PR DESCRIPTION
Hovedendringen er validering av dns-innslag. Dette gjøres 2 steder: 
- Ved validering av aurora-config for å gi fail-fast meldinger der mulig. 
- Etter opprettelse av aurora-config-objekt, hvor  @env@-uttrykk har blitt ekspandert (og dette har kanskje medført noe som vil gi en valideringsfeil)

Testene er forholdsvis verbose, men jeg synes selv ikke det gjør noe, siden jeg mener det gjør det klart hva som testes.