### PR TITLE
feature/aos-5666-global-file-validator

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/Feature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/Feature.kt
@@ -2,6 +2,7 @@ package no.skatteetaten.aurora.boober.feature
 
 import io.fabric8.kubernetes.api.model.HasMetadata
 import no.skatteetaten.aurora.boober.model.AuroraConfigFieldHandler
+import no.skatteetaten.aurora.boober.model.AuroraConfigFileType
 import no.skatteetaten.aurora.boober.model.AuroraContextCommand
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.model.AuroraResource
@@ -149,7 +150,7 @@ val AuroraDeploymentSpec.applicationPlatform: ApplicationPlatform get() = this["
 class HeaderHandlers private constructor(defaultAppName: String, defaultEnvName: String) {
 
     val handlers: Set<AuroraConfigFieldHandler>
-    val globalFile = AuroraConfigFieldHandler(GLOBAL_FILE)
+    val globalFile = AuroraConfigFieldHandler(GLOBAL_FILE, validFiles = listOf(AuroraConfigFileType.BASE, AuroraConfigFileType.ENV))
     val envFile = AuroraConfigFieldHandler(ENV_FILE)
     val baseFile = AuroraConfigFieldHandler(BASE_FILE)
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/Feature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/Feature.kt
@@ -2,7 +2,8 @@ package no.skatteetaten.aurora.boober.feature
 
 import io.fabric8.kubernetes.api.model.HasMetadata
 import no.skatteetaten.aurora.boober.model.AuroraConfigFieldHandler
-import no.skatteetaten.aurora.boober.model.AuroraConfigFileType
+import no.skatteetaten.aurora.boober.model.AuroraConfigFileType.BASE
+import no.skatteetaten.aurora.boober.model.AuroraConfigFileType.ENV
 import no.skatteetaten.aurora.boober.model.AuroraContextCommand
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.model.AuroraResource
@@ -48,78 +49,70 @@ interface Feature {
         resource.sources.add(AuroraResourceSource(this::class.java, comment = comment))
 
     /**
-      Should this feature run or not.
+    Should this feature run or not.
 
-      You can either do this via Spring Conditional annotations to react to the environment,
-      or you can react on the header and toggle if you are active in that way.
+    You can either do this via Spring Conditional annotations to react to the environment,
+    or you can react on the header and toggle if you are active in that way.
 
     If you look at BuildFeature you will see that it reacts on the Application.type to only enable
     itself if the type is development
-
      */
     fun enable(header: AuroraDeploymentSpec): Boolean = true
 
     /**
-      Return a set of Handlers, see AuroraConfigFieldHandler for details on what a handler is
+    Return a set of Handlers, see AuroraConfigFieldHandler for details on what a handler is
      */
     fun handlers(header: AuroraDeploymentSpec, cmd: AuroraContextCommand): Set<AuroraConfigFieldHandler>
 
     /**
-      Method to create a context for the given feature
+    Method to create a context for the given feature
 
-      This context will be sent to validate/generate/modify steps
+    This context will be sent to validate/generate/modify steps
 
-      The validationContext flag will let the  the context know if the context should only be used for validation
+    The validationContext flag will let the  the context know if the context should only be used for validation
 
-      You can throw an exception here and it will be registered as a validation error if you like
+    You can throw an exception here and it will be registered as a validation error if you like
      */
-    fun createContext(spec: AuroraDeploymentSpec, cmd: AuroraContextCommand, validationContext: Boolean): FeatureContext = emptyMap()
+    fun createContext(spec: AuroraDeploymentSpec, cmd: AuroraContextCommand, validationContext: Boolean)
+        : FeatureContext = emptyMap()
 
     /**
     Perform validation of this feature.
 
     If this method throws it will be handled as a single error or multiple errors if ExceptionList
-    */
-    fun validate(
-        adc: AuroraDeploymentSpec,
-        fullValidation: Boolean,
-        context: FeatureContext
-    ): List<Exception> =
-        emptyList()
+     */
+    fun validate(adc: AuroraDeploymentSpec, fullValidation: Boolean, context: FeatureContext)
+        : List<Exception> = emptyList()
 
     /**
-       Generate a set of AuroraResource from this feature
+    Generate a set of AuroraResource from this feature
 
-       Resource generation of all features are run before the modify step occurs
+    Resource generation of all features are run before the modify step occurs
 
-       If this method throws errors other features will still be run.
+    If this method throws errors other features will still be run.
 
-       If any feature has thrown an error the process will stop
+    If any feature has thrown an error the process will stop
 
-       use the generateResource method in this interface as a helper to add the correct source
-
-       If you have more then one error throw an ExceptionList
-    */
-    fun generate(adc: AuroraDeploymentSpec, context: FeatureContext): Set<AuroraResource> = emptySet()
-
-    /**
-        Modify generated resources
-
-        Resource modification of all features are run before the validate step occurs
-
-        If this method throws errors other features will still modify the resources.
-
-        If any feature has thrown an error the process will stop
-
-        use the modifyResource method in this interface as a helper to add a source to your modification
+    use the generateResource method in this interface as a helper to add the correct source
 
     If you have more then one error throw an ExceptionList
      */
-    fun modify(
-        adc: AuroraDeploymentSpec,
-        resources: Set<AuroraResource>,
-        context: FeatureContext
-    ) = Unit
+    fun generate(adc: AuroraDeploymentSpec, context: FeatureContext): Set<AuroraResource> = emptySet()
+
+    /**
+    Modify generated resources
+
+    Resource modification of all features are run before the validate step occurs
+
+    If this method throws errors other features will still modify the resources.
+
+    If any feature has thrown an error the process will stop
+
+    use the modifyResource method in this interface as a helper to add a source to your modification
+
+    If you have more then one error throw an ExceptionList
+     */
+    fun modify(adc: AuroraDeploymentSpec, resources: Set<AuroraResource>, context: FeatureContext) = Unit
 }
 
 enum class ApplicationPlatform(val baseImageName: String, val baseImageVersion: Int, val insecurePolicy: String) {
@@ -150,7 +143,7 @@ val AuroraDeploymentSpec.applicationPlatform: ApplicationPlatform get() = this["
 class HeaderHandlers private constructor(defaultAppName: String, defaultEnvName: String) {
 
     val handlers: Set<AuroraConfigFieldHandler>
-    val globalFile = AuroraConfigFieldHandler(GLOBAL_FILE, validFiles = listOf(AuroraConfigFileType.BASE, AuroraConfigFileType.ENV))
+    val globalFile = AuroraConfigFieldHandler(GLOBAL_FILE, allowedFilesTypes = setOf(BASE, ENV))
     val envFile = AuroraConfigFieldHandler(ENV_FILE)
     val baseFile = AuroraConfigFieldHandler(BASE_FILE)
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigFieldHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigFieldHandler.kt
@@ -23,5 +23,7 @@ data class AuroraConfigFieldHandler(
     val defaultValue: Any? = null,
     val defaultSource: String = "default",
     val canBeSimplifiedConfig: Boolean = false,
-    val validFiles: List<AuroraConfigFileType>? = null
+
+    // The file types this config field can be declared in. <code>null</code> means no restriction.
+    val allowedFilesTypes: Set<AuroraConfigFileType>? = null
 )

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigFieldHandler.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/model/AuroraConfigFieldHandler.kt
@@ -22,5 +22,6 @@ data class AuroraConfigFieldHandler(
     @JsonIgnore val validator: Validator = defaultValidator,
     val defaultValue: Any? = null,
     val defaultSource: String = "default",
-    val canBeSimplifiedConfig: Boolean = false
+    val canBeSimplifiedConfig: Boolean = false,
+    val validFiles: List<AuroraConfigFileType>? = null
 )

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecConfigFieldValidator.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecConfigFieldValidator.kt
@@ -38,10 +38,10 @@ class AuroraDeploymentSpecConfigFieldValidator(
                         )
                     }
 
-                val invalidFileResult: Boolean = e.validFiles?.let { !it.contains(rawField.fileType) } ?: false
+                val fieldDeclaredInAllowedFile: Boolean = e.allowedFilesTypes?.contains(rawField.fileType) ?: true
 
                 logger.trace("Validating field=${e.name}")
-                val auroraConfigField: JsonNode? = rawField.value
+                val auroraConfigField: JsonNode = rawField.value
                 logger.trace("value is=${jacksonObjectMapper().writeValueAsString(auroraConfigField)}")
 
                 val result = e.validator(auroraConfigField)
@@ -52,8 +52,8 @@ class AuroraDeploymentSpecConfigFieldValidator(
                         "Invalid Source field=${e.name} requires an about source. Actual source is source=${rawField.name}",
                         e.name, rawField
                     )
-                    invalidFileResult -> ConfigFieldErrorDetail.illegal(
-                        "Invalid Source field=${e.name}. Actual source=${rawField.name} (File type: ${rawField.fileType}). Must be placed within files of type: ${e.validFiles}",
+                    !fieldDeclaredInAllowedFile -> ConfigFieldErrorDetail.illegal(
+                        "Invalid Source field=${e.name}. Actual source=${rawField.name} (File type: ${rawField.fileType}). Must be placed within files of type: ${e.allowedFilesTypes}",
                         e.name,
                         rawField
                     )

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecConfigFieldValidator.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/AuroraDeploymentSpecConfigFieldValidator.kt
@@ -38,6 +38,8 @@ class AuroraDeploymentSpecConfigFieldValidator(
                         )
                     }
 
+                val invalidFileResult: Boolean = e.validFiles?.let { !it.contains(rawField.fileType) } ?: false
+
                 logger.trace("Validating field=${e.name}")
                 val auroraConfigField: JsonNode? = rawField.value
                 logger.trace("value is=${jacksonObjectMapper().writeValueAsString(auroraConfigField)}")
@@ -49,6 +51,11 @@ class AuroraDeploymentSpecConfigFieldValidator(
                     invalidEnvSource -> ConfigFieldErrorDetail.illegal(
                         "Invalid Source field=${e.name} requires an about source. Actual source is source=${rawField.name}",
                         e.name, rawField
+                    )
+                    invalidFileResult -> ConfigFieldErrorDetail.illegal(
+                        "Invalid Source field=${e.name}. Actual source=${rawField.name} (File type: ${rawField.fileType}). Must be placed within files of type: ${e.validFiles}",
+                        e.name,
+                        rawField
                     )
                     result == null -> null
                     auroraConfigField != null -> ConfigFieldErrorDetail.illegal(

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/facade/AuroraConfigFacadeTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/facade/AuroraConfigFacadeTest.kt
@@ -659,4 +659,22 @@ class AuroraConfigFacadeTest(
 
         assertThat(spec.get<String>("globalFile")).isEqualTo("about-alternative1.json")
     }
+
+    @Test
+    fun `Should throw error if globalFile field is placed illegally`() {
+
+        assertThat { facade.findAuroraDeploymentSpecSingle(
+            ref = auroraConfigRef,
+            adr = ApplicationDeploymentRef("include", "include"),
+            overrideFiles = listOf(
+                AuroraConfigFile(
+                    "include/include.json",
+                    override = true,
+                    contents = """{ "globalFile": "about-alternative1.json"}"""
+                )
+            ),
+            errorsAsWarnings = false)
+        }.isNotNull().isFailure()
+            .messageContains("Config for application include in environment include contains errors. Invalid Source field=globalFile. Actual source=include/include.json.override (File type: APP). Must be placed within files of type: [BASE, ENV].")
+    }
 }


### PR DESCRIPTION
Denne branchen introduserer støtte for å sette hvilke filtyper som er lovlig for spesifikke AuroraConfig fields. Vil gi brukeren feedback på om et config field er ugyldig plassert, og si i hvilken filtype den kan bli plassert