### PR TITLE
fixed bug not including openshift kind for sgoa

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/resourceprovisioning/S3StorageGridProvisioner.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/resourceprovisioning/S3StorageGridProvisioner.kt
@@ -193,6 +193,6 @@ class S3StorageGridProvisioner(
     }
 }
 
-private fun HasMetadata.toGetCommand() = OpenshiftCommand(GET, this.toJson().appropriateNamedUrl)
+private fun HasMetadata.toGetCommand() = OpenshiftCommand(GET, this.toJson().appropriateNamedUrl, this.toJson())
 
 private fun HasMetadata.toJson() = jacksonObjectMapper().convertValue<JsonNode>(this)


### PR DESCRIPTION
Uten denne endringen så stoppet deploy med feilen: `Kind must be set in file=null`
Legger til seg selv som payload til OpenShiftCommand. Siden det er GET så brukes payload kun for å hente ut **kind** for å sette opp riktig klient mot OpenShift.