### PR TITLE
removed s3 variant minio for local spring configuration, causing open…

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,6 +48,10 @@ integrations:
         backoff: 500
     docker:
         registry: "docker-registry.aurora.sits.no:5000"
+    operations:
+        scope: ""
+    s3:
+        variant: storagegrid
 
 boober:
     openshift:
@@ -102,8 +106,6 @@ integrations:
         url: https://dbh-aurora.${openshift.cluster}.paas.skead.no
     cantus:
         url: http://cantus-aurora.${openshift.cluster}.paas.skead.no
-    s3:
-        variant: storagegrid
     skap:
         url: https://skap-aurora.${openshift.cluster}.paas.skead.no
     fiona:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,8 +22,6 @@ integrations:
         url: "http://cantus"
     bigbird:
         url: "https://bigbird-appsikk.${openshift.cluster}.paas.skead.no/.well-known/discovery"
-    s3:
-        variant: minio
     deployLog:
         git:
             project: "ao"


### PR DESCRIPTION
removed `integration.s3.variant: minio` in local application because it caused the application to fail on startup, since it depends on fiona-url, which was not configured.