### PR TITLE
Removable alerts fix

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftCommandService.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/OpenShiftCommandService.kt
@@ -186,7 +186,8 @@ class OpenShiftCommandService(
 
         val labelSelectors = listOf("app=$name", "booberDeployId", "booberDeployId!=$deployId")
         return apiResources
-            .filter { kind -> !kind.toLowerCase().equals("auroracname") || openShiftClient.k8sVersionOfAtLeast("1.16") }
+            .filter { kind -> kind.toLowerCase() != "auroracname" || openShiftClient.k8sVersionOfAtLeast("1.16") }
+            .filter { kind -> kind.toLowerCase() != "alert" || openShiftClient.k8sVersionOfAtLeast("1.16") }
             .flatMap { kind -> openShiftClient.getByLabelSelectors(kind, namespace, labelSelectors) }
             .map {
                 try {


### PR DESCRIPTION
legger til filtrering slik at boober ikke forsøker å opprette delete command for alert for kubernetes versjon < 1.16