### PR TITLE
SITJ-1719 Recreate route used for webseal if flagged

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("no.skatteetaten.gradle.aurora") version "4.3.20"
+    id("no.skatteetaten.gradle.aurora") version "4.3.22"
 }
 
 aurora {
@@ -46,7 +46,7 @@ dependencies {
     testImplementation("io.mockk:mockk:1.12.0")
     testImplementation("com.willowtreeapps.assertk:assertk-jvm:0.25")
     testImplementation("no.skatteetaten.aurora:mockmvc-extensions-kotlin:1.1.7")
-    testImplementation("no.skatteetaten.aurora:mockwebserver-extensions-kotlin:1.1.8")
+    testImplementation("no.skatteetaten.aurora:mockwebserver-extensions-kotlin:1.2.0")
     testImplementation("com.ninja-squad:springmockk:3.0.1")
 }
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/WebsealFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/WebsealFeature.kt
@@ -16,6 +16,14 @@ import org.springframework.stereotype.Service
 val WEBSEAL_ROLES_ANNOTATION: String = "marjory.sits.no/route.roles"
 val WEBSEAL_DONE_ANNOTATION: String = "marjory.sits.no-routes-config.done"
 
+val AuroraDeploymentSpec.isWebsealEnabled: Boolean
+    get() {
+        return (
+            this.getOrNull<String>("webseal")?.let { it == "true" } == true ||
+                this.getOrNull<String>("webseal/host") != null
+            )
+    }
+
 @ConditionalOnPropertyMissingOrEmpty("integrations.skap.url")
 @Service
 class WebsealDisabledFeature : AbstractWebsealFeature("") {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AuroraAzureAppSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AuroraAzureAppSubPart.kt
@@ -77,7 +77,7 @@ class AuroraAzureAppSubPart {
     ): AuroraResource? {
         if (adc.isAzureRouteManaged) {
             val configuredRoute = ConfiguredRoute(
-                objectName = "${adc.name}-webseal",
+                objectName = "${adc.name}-managed",
                 host = adc.getOrNull<String>(azureAppFqdn)!!,
                 annotations = emptyMap(),
                 fullyQualifiedHost = true,

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AuroraAzureAppSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AuroraAzureAppSubPart.kt
@@ -99,7 +99,7 @@ class AuroraAzureAppSubPart {
     fun validate(
         adc: AuroraDeploymentSpec
     ): List<Exception> {
-        val errors = ArrayList<Exception>()
+        val errors = mutableListOf<Exception>()
         if (adc.azureAppFqdn == null || adc.azureAppGroups == null) {
             if (!(adc.azureAppFqdn == null && adc.azureAppGroups == null)) {
                 errors.add(AuroraDeploymentSpecValidationException("You need to configure either both or none of ${ConfigPath.azureAppFqdn} and ${ConfigPath.groups}"))

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AuroraAzureAppSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AuroraAzureAppSubPart.kt
@@ -2,7 +2,6 @@ package no.skatteetaten.aurora.boober.feature.azure
 
 import com.fkorotkov.kubernetes.newObjectMeta
 import no.skatteetaten.aurora.boober.feature.ConfiguredRoute
-import no.skatteetaten.aurora.boober.feature.azure.AuroraAzureAppSubPart.ConfigPath.azureAppFqdn
 import no.skatteetaten.aurora.boober.feature.azure.AuroraAzureAppSubPart.ConfigPath.managedRoute
 import no.skatteetaten.aurora.boober.feature.isWebsealEnabled
 import no.skatteetaten.aurora.boober.feature.name
@@ -75,25 +74,26 @@ class AuroraAzureAppSubPart {
         adc: AuroraDeploymentSpec,
         azureFeature: AzureFeature
     ): AuroraResource? {
-        if (adc.isAzureRouteManaged) {
-            val configuredRoute = ConfiguredRoute(
-                objectName = "${adc.name}-managed",
-                host = adc.getOrNull<String>(azureAppFqdn)!!,
-                annotations = emptyMap(),
-                fullyQualifiedHost = true,
-                labels = mapOf(
-                    "type" to "webseal"
-                )
-            )
-
-            val openshiftRoute = configuredRoute.generateOpenShiftRoute(
-                routeNamespace = adc.namespace,
-                serviceName = adc.name,
-                routeSuffix = ""
-            )
-            return azureFeature.generateResource(openshiftRoute)
+        if (!adc.isAzureRouteManaged) {
+            return null
         }
-        return null
+        val configuredRoute = ConfiguredRoute(
+            objectName = "${adc.name}-managed",
+            host = adc.getOrNull<String>(ConfigPath.azureAppFqdn)!!,
+            annotations = emptyMap(),
+            fullyQualifiedHost = true,
+            labels = mapOf(
+                "type" to "webseal",
+                "azureManaged" to "true"
+            )
+        )
+
+        val openshiftRoute = configuredRoute.generateOpenShiftRoute(
+            routeNamespace = adc.namespace,
+            serviceName = adc.name,
+            routeSuffix = ""
+        )
+        return azureFeature.generateResource(openshiftRoute)
     }
 
     fun validate(

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -60,7 +60,19 @@ class AzureFeature(
             AuroraConfigFieldHandler(
                 AuroraAzureAppSubPart.ConfigPath.groups,
                 validator = { it.isListOrEmpty(required = false) }
-            )
+            ),
+            AuroraConfigFieldHandler(
+                AuroraAzureAppSubPart.ConfigPath.managedRoute,
+                defaultValue = false,
+                validator = { it.boolean() }
+            ),
+            AuroraConfigFieldHandler(
+                "webseal",
+                defaultValue = false,
+                validator = { it.boolean() },
+                canBeSimplifiedConfig = true
+            ),
+            AuroraConfigFieldHandler("webseal/host") // Needed to be able to run tests
         )
     }
 

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
@@ -141,7 +141,7 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
         assertThat(websealRoute).auroraResourceCreatedByTarget(WebsealFeature::class.java)
             .auroraResourceMatchesFile("webseal-route.json")
 
-        // Trying to document that assert fails, not entirely sure if it is the best way:
+        // Trying to document that assert fails:
         Assertions.assertThrows(AssertionFailedError::class.java) {
             assertThat(auroraAzureApp).auroraResourceCreatedByTarget(DatabaseFeature::class.java)
         }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
@@ -10,7 +10,6 @@ import no.skatteetaten.aurora.boober.service.MultiApplicationValidationException
 import no.skatteetaten.aurora.boober.utils.AbstractMultiFeatureTest
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.opentest4j.AssertionFailedError
 
@@ -217,7 +216,6 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
     }
 
     @Test
-    @Disabled(value = "This is WIP, disabled just to push buildable version of work")
     fun `AuroraAzureApp without clinger, with managedRoute, and no webseal is valid`() {
         val (_, auroraAzureApp, alternativeRoute) = generateResources(
             """{
@@ -227,12 +225,12 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
                 "groups": []
               }
             }""",
-            mutableSetOf(createEmptyDeploymentConfig(), createEmptyDeploymentConfig()), createdResources = 1
+            mutableSetOf(createEmptyDeploymentConfig(), createEmptyDeploymentConfig()), createdResources = 2
         )
         assertThat(auroraAzureApp).auroraResourceCreatedByTarget(AzureFeature::class.java)
             .auroraResourceMatchesFile("aurora-azure-app.json")
-        assertThat(alternativeRoute).auroraResourceCreatedByTarget(WebsealFeature::class.java)
+        assertThat(alternativeRoute).auroraResourceCreatedByTarget(AzureFeature::class.java)
             // WIP Possibly a differently formatted file:
-            .auroraResourceMatchesFile("webseal-saksmappe-route.json")
+            .auroraResourceMatchesFile("webseal-replacement-route.json")
     }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
@@ -535,6 +535,16 @@
           }
         ]
       }
+    },
+    "managedRoute": {
+      "source": "default",
+      "value": false,
+      "sources": [
+        {
+          "name": "default",
+          "value": false
+        }
+      ]
     }
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
@@ -61,3 +61,4 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |   managedRoute: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -1451,6 +1451,16 @@
           }
         ]
       }
+    },
+    "managedRoute": {
+      "source": "default",
+      "value": false,
+      "sources": [
+        {
+          "name": "default",
+          "value": false
+        }
+      ]
     }
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -164,3 +164,4 @@ utv/about-alternate.json |   ttl: "1d"
                  default |     enabled: false
                  default |     version: "0.4.0"
                  default |     ivGroupsRequired: false
+                 default |   managedRoute: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
@@ -747,6 +747,16 @@
           }
         ]
       }
+    },
+    "managedRoute": {
+      "source": "default",
+      "value": false,
+      "sources": [
+        {
+          "name": "default",
+          "value": false
+        }
+      ]
     }
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
@@ -70,3 +70,4 @@ utv/python.json | sts: true
         default |     enabled: false
         default |     version: "0.4.0"
         default |     ivGroupsRequired: false
+        default |   managedRoute: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
@@ -699,6 +699,16 @@
           }
         ]
       }
+    },
+    "managedRoute": {
+      "source": "default",
+      "value": false,
+      "sources": [
+        {
+          "name": "default",
+          "value": false
+        }
+      ]
     }
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
@@ -70,3 +70,4 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |   managedRoute: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
@@ -755,6 +755,16 @@
           }
         ]
       }
+    },
+    "managedRoute": {
+      "source": "default",
+      "value": false,
+      "sources": [
+        {
+          "name": "default",
+          "value": false
+        }
+      ]
     }
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
@@ -79,3 +79,4 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |   managedRoute: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
@@ -717,6 +717,16 @@
           }
         ]
       }
+    },
+    "managedRoute": {
+      "source": "default",
+      "value": false,
+      "sources": [
+        {
+          "name": "default",
+          "value": false
+        }
+      ]
     }
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
@@ -74,3 +74,4 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |   managedRoute: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/aurora-azure-app-with-webseal.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/aurora-azure-app-with-webseal.json
@@ -1,0 +1,14 @@
+{
+  "apiVersion": "skatteetaten.no/v1",
+  "kind": "AuroraAzureApp",
+  "metadata": {
+    "name": "simple",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "azureAppFqdn": "saksmappa.amutv.skead.no",
+    "appName": "simple",
+    "groups": ["APP_dev","APP_DRIFT"],
+    "noProxy": true
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-replacement-route.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-replacement-route.json
@@ -1,0 +1,21 @@
+{
+  "apiVersion": "route.openshift.io/v1",
+  "kind": "Route",
+  "metadata": {
+    "labels": {
+      "type": "webseal"
+    },
+    "name": "simple-webseal",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "host": "saksmappa.amutv.skead.no",
+    "port": {
+      "targetPort": "http"
+    },
+    "to": {
+      "kind": "Service",
+      "name": "simple"
+    }
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-replacement-route.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-replacement-route.json
@@ -3,7 +3,8 @@
   "kind": "Route",
   "metadata": {
     "labels": {
-      "type": "webseal"
+      "type": "webseal",
+      "azureManaged": "true"
     },
     "name": "simple-managed",
     "namespace": "paas-utv"

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-replacement-route.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-replacement-route.json
@@ -5,7 +5,7 @@
     "labels": {
       "type": "webseal"
     },
-    "name": "simple-webseal",
+    "name": "simple-managed",
     "namespace": "paas-utv"
   },
   "spec": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-route.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-route.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "route.openshift.io/v1",
+  "kind": "Route",
+  "metadata": {
+    "annotations": {
+      "marjory.sits.no/isOpen": "false",
+      "marjory.sits.no/route.roles": ""
+    },
+    "labels": {
+      "type": "webseal"
+    },
+    "name": "simple-webseal",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "host": "simple-paas-utv.test.skead.no",
+    "port": {
+      "targetPort": "http"
+    },
+    "to": {
+      "kind": "Service",
+      "name": "simple"
+    }
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-saksmappe-route.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest/webseal-saksmappe-route.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "route.openshift.io/v1",
+  "kind": "Route",
+  "metadata": {
+    "annotations": {
+      "marjory.sits.no/isOpen": "false",
+      "marjory.sits.no/route.roles": "APP_dev,APP_drift"
+    },
+    "labels": {
+      "type": "webseal"
+    },
+    "name": "simple-webseal",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "host": "saksmappa.test.skead.no",
+    "port": {
+      "targetPort": "http"
+    },
+    "to": {
+      "kind": "Service",
+      "name": "simple"
+    }
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
@@ -1,0 +1,120 @@
+{
+  "apiVersion": "apps.openshift.io/v1",
+  "kind": "DeploymentConfig",
+  "metadata": {
+    "name": "simple",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "name": "simple"
+    },
+    "strategy": {
+      "rollingParams": {
+        "intervalSeconds": 1,
+        "maxSurge": "25%",
+        "maxUnavailable": 0,
+        "timeoutSeconds": 180,
+        "updatePeriodSeconds": 1
+      },
+      "type": "Rolling"
+    },
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "simple"
+          },
+          {
+            "env": [
+              {
+                "name": "CLINGER_PROXY_SERVER_PORT",
+                "value": "8100"
+              },
+              {
+                "name": "CLINGER_MANAGEMENT_SERVER_PORT",
+                "value": "8101"
+              }, {
+                "name": "CLINGER_PROXY_BACKEND_HOST",
+                "value" : "0.0.0.0"
+              }, {
+                "name": "CLINGER_PROXY_BACKEND_PORT",
+                "value" : "8080"
+              }, {
+                "name": "CLINGER_PROXY_SERVER_PORT",
+                "value" : "8100"
+              }, {
+                "name": "CLINGER_WEBSEAL_TRAFFIC_ACCEPTED",
+                "value" : "true"
+              }, {
+                "name": "CLINGER_DISCOVERY_URL",
+                "value" : "https://endpoint"
+              }, {
+                "name": "CLINGER_IV_GROUPS_REQUIRED",
+                "value" : "false"
+              }
+            ],
+            "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/liveness",
+                "port": 8101
+              },
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 2
+            },
+            "name": "simple-clinger-mix",
+            "ports": [
+              {
+                "containerPort": 8100,
+                "name": "http",
+                "protocol": "TCP"
+              },
+              {
+                "containerPort": 8101,
+                "name": "management",
+                "protocol": "TCP"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/ready",
+                "port": 8101
+              },
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 2
+            },
+            "resources": {
+              "limits": {
+                "memory": "256Mi",
+                "cpu": "1"
+              },
+              "requests": {
+                "memory": "128Mi",
+                "cpu": "25m"
+              }
+            }
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always"
+      }
+    },
+    "triggers": [
+      {
+        "imageChangeParams": {
+          "automatic": true,
+          "containerNames": [
+            "simple"
+          ],
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "simple:default"
+          }
+        },
+        "type": "ImageChange"
+      }
+    ]
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/webseal-route.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/webseal-route.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "route.openshift.io/v1",
+  "kind": "Route",
+  "metadata": {
+    "annotations": {
+      "marjory.sits.no/isOpen": "false",
+      "marjory.sits.no/route.roles": ""
+    },
+    "labels": {
+      "type": "webseal"
+    },
+    "name": "simple-webseal",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "host": "simple-paas-utv.test.skead.no",
+    "port": {
+      "targetPort": "http"
+    },
+    "to": {
+      "kind": "Service",
+      "name": "simple"
+    }
+  }
+}


### PR DESCRIPTION
Dersom  flagget `managedRoute: true ` er satt, skal route lignende det som fantes for webseal bli produsert. Dette er for å lette migrering vekk fra webseal.

Merk at denne PRen endrer litt på hvordan tester blir utført. Nå er det slik at det er mulig å teste elementer fra flere Features samtidig. For AzureFeature måtte jeg legge til konfigfelt for "webseal" slik at feltet kunne bli plukket opp for tester.