### PR TITLE
SITJ-1467 Move validation in order to avoid validation error on ocp3

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/MountFeature.kt
@@ -150,12 +150,12 @@ class MountFeature(
 
         val errors = validateExistinAndSecretVault(mounts)
             .addIfNotNull(validatePSATMounts(mounts))
-            .addIfNotNull(ensureCompatibleKuberntesForPSATMounts(mounts))
         // .addIfNotNull(validatePVCMounts(mounts))
         if (!fullValidation || adc.cluster != cluster) {
             return errors
         }
         return errors
+            .addIfNotNull(ensureCompatibleKuberntesForPSATMounts(mounts))
             .addIfNotNull(validateExistingMounts(mounts, adc))
             .addIfNotNull(validateVaultExistence(mounts, adc))
     }


### PR DESCRIPTION
Ved validering av auroraconfig ved push, vil valideringen feile om det finnes PSAT eller azure definert, og du er logget inn mot boober på OCP3.

Eksempel på hvordan feil fortoner seg:
```
Application: psat-poc/client
Message:     PSAT mount=psat-token-mount is not valid, as kubernetes version is below 1.16

Application: k15321/cname-intend-to-fail
Filename:    k15321/cname-intend-to-fail.yaml
Field:       /azure
Message:     /azure is not a valid config field pointer
```