### PR TITLE
AOS-6150 harmonisering av tokensnippet-generering

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/controller/security/User.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/controller/security/User.kt
@@ -28,7 +28,7 @@ class User(
     }
 
     val tokenSnippet: String
-        get() = token.takeLast(5)
+        get() = token.takeLast(Integer.min(token.length, 5))
 
     val groupNames: List<String>
         get() = authorities.map { it.authority }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/utils/RetryingRestTemplateWrapper.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/utils/RetryingRestTemplateWrapper.kt
@@ -190,10 +190,7 @@ class RetryLogger(val logger: Logger) : RetryListenerSupport() {
                 ?.firstOrNull()
                 ?.split(" ")
                 ?.get(1)?.let {
-                    if (it.startsWith("sha256") && it.length >= 11)
-                        it.substring(6, 11)
-                    else
-                        it.substring(0, Integer.min(it.length, 5))
+                    it.takeLast(Integer.min(it.length, 5))
                 }
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftRestTemplateWrapperTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/OpenShiftRestTemplateWrapperTest.kt
@@ -85,7 +85,7 @@ class OpenShiftRestTemplateWrapperTest : ResourceLoader() {
     fun `Get token snippet from auth header`() {
 
         val token = "some_long_token"
-        val snippet = "some_"
+        val snippet = "token"
         val httpHeaders = HttpHeaders().apply {
             add(HttpHeaders.AUTHORIZATION, "Authorization $token")
         }
@@ -95,8 +95,19 @@ class OpenShiftRestTemplateWrapperTest : ResourceLoader() {
     @Test
     fun `Get sha256 token snippet from auth header`() {
 
-        val token = "sha25609876"
+        val token = "sha256~09876"
         val snippet = "09876"
+        val httpHeaders = HttpHeaders().apply {
+            add(HttpHeaders.AUTHORIZATION, "Bearer $token")
+        }
+        assertThat(RetryLogger.getTokenSnippetFromAuthHeader(httpHeaders)).isEqualTo(snippet)
+    }
+
+    @Test
+    fun `Get token snippet from short token in auth header`() {
+
+        val token = "9876"
+        val snippet = "9876"
         val httpHeaders = HttpHeaders().apply {
             add(HttpHeaders.AUTHORIZATION, "Bearer $token")
         }


### PR DESCRIPTION
AOS-6006 avslørte en svakhet til med tokenSnippets i boober i form av ulike måter å trekke ut snippet på.  Sørger for samme uttrekk der snippet genereres (siste 5 tegn)