### PR TITLE
AOS-6260: Legger til mulighet for å velge at en proxy skal være deaktivert fra start

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeature.kt
@@ -120,6 +120,11 @@ class ToxiproxySidecarFeature(
                     "$endpoint/enabled",
                     defaultValue = true,
                     validator = { it.boolean() }
+                ),
+                AuroraConfigFieldHandler(
+                    "$endpoint/initialEnabledState",
+                    defaultValue = true,
+                    validator = { it.boolean() }
                 )
             )
         }
@@ -135,6 +140,11 @@ class ToxiproxySidecarFeature(
                 AuroraConfigFieldHandler(
                     "$proxyname/portVariable",
                     validator = { it.notBlank("Port variable must be set") }
+                ),
+                AuroraConfigFieldHandler(
+                    "$proxyname/initialEnabledState",
+                    defaultValue = true,
+                    validator = { it.boolean() }
                 )
             )
         }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarSpec.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarSpec.kt
@@ -17,14 +17,15 @@ val AuroraDeploymentSpec.toxiproxyVersion: String?
 data class ToxiproxyConfig(
     val name: String = "app",
     val listen: String = "0.0.0.0:" + PortNumbers.TOXIPROXY_HTTP_PORT,
-    val upstream: String = "0.0.0.0:" + PortNumbers.INTERNAL_HTTP_PORT
+    val upstream: String = "0.0.0.0:" + PortNumbers.INTERNAL_HTTP_PORT,
+    val enabled: Boolean = true
 )
 
 data class ToxiproxyServerAndPortVars(val proxyname: String, val serverVar: String, val portVar: String)
 
 // Regex for matching a variable name in an endpoint field name
 val varNameInEndpointFieldNameRegex =
-    Regex("(?<=^toxiproxy\\/endpointsFromConfig\\/)([^\\/]+(?=\\/enabled\$|\\/proxyname\$|\$))")
+    Regex("(?<=^toxiproxy\\/endpointsFromConfig\\/)([^\\/]+(?=\\/enabled\$|\\/proxyname\$|\\/initialEnabledState\$|\$))")
 
 fun findVarNameInEndpointFieldName(fieldName: String) = varNameInEndpointFieldNameRegex.find(fieldName)!!.value
 
@@ -55,7 +56,7 @@ fun generateProxyNameFromVarName(varName: String) = "endpoint_$varName"
 
 // Regex for matching a proxy name in a server and port field name
 val proxyNameInServerAndPortFieldNameRegex =
-    Regex("(?<=^toxiproxy\\/serverAndPortFromConfig\\/)([^\\/]+(?=\\/serverVariable\$|\\/portVariable\$|\$))")
+    Regex("(?<=^toxiproxy\\/serverAndPortFromConfig\\/)([^\\/]+(?=\\/serverVariable\$|\\/portVariable\$|\\/initialEnabledState\$|\$))")
 
 fun findProxyNameInServerAndPortFieldName(fieldName: String) = proxyNameInServerAndPortFieldNameRegex.find(fieldName)!!.value
 

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest.kt
@@ -90,7 +90,9 @@ class ToxiproxySidecarFeatureTest : AbstractMultiFeatureTest() {
                         "DISABLED_TEST_WITHOUT_PROXYNAME": false,
                         "HTTPS_URL": {"proxyname": "test5", "enabled": true},
                         "URL_WITH_PORT": {"proxyname": "test6", "enabled": true},
-                        "URL_WITH_PATH": {"proxyname": "test7", "enabled": true}
+                        "URL_WITH_PATH": {"proxyname": "test7", "enabled": true},
+                        "INITIALLY_ENABLED": {"proxyname": "test8", "enabled": true, "initialEnabledState": true},
+                        "INITIALLY_DISABLED": {"proxyname": "test9", "enabled": true, "initialEnabledState": false}
                     }
                 },
                 "config": {
@@ -100,7 +102,9 @@ class ToxiproxySidecarFeatureTest : AbstractMultiFeatureTest() {
                     "DISABLED_TEST_WITHOUT_PROXYNAME": "http://test4.test",
                     "HTTPS_URL": "https://test5.test",
                     "URL_WITH_PORT": "http://test6.test:1234",
-                    "URL_WITH_PATH": "http://test7.test/path"
+                    "URL_WITH_PATH": "http://test7.test/path",
+                    "INITIALLY_ENABLED": "http://test8.test",
+                    "INITIALLY_DISABLED": "http://test9.test"
                 }
             }""",
             createEmptyService(),
@@ -143,7 +147,13 @@ class ToxiproxySidecarFeatureTest : AbstractMultiFeatureTest() {
                         },
                         "proxyName2": {
                             "serverVariable": "SERVER_2",
-                            "portVariable": "PORT_2"
+                            "portVariable": "PORT_2",
+                            "initialEnabledState": true
+                        },
+                        "proxyName3": {
+                            "serverVariable": "SERVER_3",
+                            "portVariable": "PORT_3",
+                            "initialEnabledState": false
                         }
                     }
                 },
@@ -151,7 +161,9 @@ class ToxiproxySidecarFeatureTest : AbstractMultiFeatureTest() {
                     "SERVER_1": "test1.test",
                     "PORT_1": 123,
                     "SERVER_2": "test2.test",
-                    "PORT_2": 124
+                    "PORT_2": 124,
+                    "SERVER_3": "test3.test",
+                    "PORT_3": 125
                 }
             }""",
             createEmptyService(),

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarSpecTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarSpecTest.kt
@@ -12,9 +12,11 @@ class ToxiproxySidecarSpecTest {
             "toxiproxy/endpointsFromConfig/test" to "test",
             "toxiproxy/endpointsFromConfig/test/enabled" to "test",
             "toxiproxy/endpointsFromConfig/test/proxyname" to "test",
+            "toxiproxy/endpointsFromConfig/test/initialEnabledState" to "test",
             "toxiproxy/endpointsFromConfig/test2" to "test2",
             "toxiproxy/endpointsFromConfig/test2/enabled" to "test2",
-            "toxiproxy/endpointsFromConfig/test2/proxyname" to "test2"
+            "toxiproxy/endpointsFromConfig/test2/proxyname" to "test2",
+            "toxiproxy/endpointsFromConfig/test2/initialEnabledState" to "test2"
         ).forEach { (fieldName, expectedResult) ->
             assertThat(findVarNameInEndpointFieldName(fieldName)).isEqualTo(expectedResult)
         }
@@ -25,8 +27,10 @@ class ToxiproxySidecarSpecTest {
         mapOf(
             "toxiproxy/serverAndPortFromConfig/test/serverVariable" to "test",
             "toxiproxy/serverAndPortFromConfig/test/portVariable" to "test",
+            "toxiproxy/serverAndPortFromConfig/test/initialEnabledState" to "test",
             "toxiproxy/serverAndPortFromConfig/test2/serverVariable" to "test2",
-            "toxiproxy/serverAndPortFromConfig/test2/portVariable" to "test2"
+            "toxiproxy/serverAndPortFromConfig/test2/portVariable" to "test2",
+            "toxiproxy/serverAndPortFromConfig/test2/initialEnabledState" to "test2"
         ).forEach { (fieldName, expectedResult) ->
             assertThat(findProxyNameInServerAndPortFieldName(fieldName)).isEqualTo(expectedResult)
         }
@@ -35,9 +39,9 @@ class ToxiproxySidecarSpecTest {
     @Test
     fun getNextPortNumberTest() {
         val toxiproxyConfigs = listOf(
-            ToxiproxyConfig("proxyname1", "0.0.0.0:18000", "test1.test:80"),
-            ToxiproxyConfig("proxyname3", "0.0.0.0:18003", "test3.test:80"),
-            ToxiproxyConfig("proxyname2", "0.0.0.0:18001", "test2.test:80")
+            ToxiproxyConfig("proxyname1", "0.0.0.0:18000", "test1.test:80", true),
+            ToxiproxyConfig("proxyname3", "0.0.0.0:18003", "test3.test:80", true),
+            ToxiproxyConfig("proxyname2", "0.0.0.0:18001", "test2.test:80", true)
         )
         val numberIfEmpty = 18000
         assertThat(toxiproxyConfigs.getNextPortNumber(numberIfEmpty)).isEqualTo(18004)

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/config.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/config.json
@@ -6,6 +6,6 @@
     "namespace": "paas-utv"
   },
   "data": {
-    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\"}]"
+    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true}]"
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithEndpointMapping.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithEndpointMapping.json
@@ -6,6 +6,6 @@
     "namespace": "paas-utv"
   },
   "data": {
-    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\"},{\"name\":\"test1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:80\"},{\"name\":\"endpoint_TEST_WITHOUT_PROXYNAME\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:80\"},{\"name\":\"test5\",\"listen\":\"0.0.0.0:18002\",\"upstream\":\"test5.test:443\"},{\"name\":\"test6\",\"listen\":\"0.0.0.0:18003\",\"upstream\":\"test6.test:1234\"},{\"name\":\"test7\",\"listen\":\"0.0.0.0:18004\",\"upstream\":\"test7.test:80\"}]"
+    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true},{\"name\":\"test1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:80\",\"enabled\":true},{\"name\":\"endpoint_TEST_WITHOUT_PROXYNAME\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:80\",\"enabled\":true},{\"name\":\"test5\",\"listen\":\"0.0.0.0:18002\",\"upstream\":\"test5.test:443\",\"enabled\":true},{\"name\":\"test6\",\"listen\":\"0.0.0.0:18003\",\"upstream\":\"test6.test:1234\",\"enabled\":true},{\"name\":\"test7\",\"listen\":\"0.0.0.0:18004\",\"upstream\":\"test7.test:80\",\"enabled\":true}]"
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithEndpointMapping.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithEndpointMapping.json
@@ -6,6 +6,6 @@
     "namespace": "paas-utv"
   },
   "data": {
-    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true},{\"name\":\"test1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:80\",\"enabled\":true},{\"name\":\"endpoint_TEST_WITHOUT_PROXYNAME\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:80\",\"enabled\":true},{\"name\":\"test5\",\"listen\":\"0.0.0.0:18002\",\"upstream\":\"test5.test:443\",\"enabled\":true},{\"name\":\"test6\",\"listen\":\"0.0.0.0:18003\",\"upstream\":\"test6.test:1234\",\"enabled\":true},{\"name\":\"test7\",\"listen\":\"0.0.0.0:18004\",\"upstream\":\"test7.test:80\",\"enabled\":true}]"
+    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true},{\"name\":\"test1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:80\",\"enabled\":true},{\"name\":\"endpoint_TEST_WITHOUT_PROXYNAME\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:80\",\"enabled\":true},{\"name\":\"test5\",\"listen\":\"0.0.0.0:18002\",\"upstream\":\"test5.test:443\",\"enabled\":true},{\"name\":\"test6\",\"listen\":\"0.0.0.0:18003\",\"upstream\":\"test6.test:1234\",\"enabled\":true},{\"name\":\"test7\",\"listen\":\"0.0.0.0:18004\",\"upstream\":\"test7.test:80\",\"enabled\":true},{\"name\":\"test8\",\"listen\":\"0.0.0.0:18005\",\"upstream\":\"test8.test:80\",\"enabled\":true},{\"name\":\"test9\",\"listen\":\"0.0.0.0:18006\",\"upstream\":\"test9.test:80\",\"enabled\":false}]"
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithServerAndPortMapping.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithServerAndPortMapping.json
@@ -6,6 +6,6 @@
     "namespace": "paas-utv"
   },
   "data": {
-    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\"},{\"name\":\"proxyName1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:123\"},{\"name\":\"proxyName2\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:124\"}]"
+    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true},{\"name\":\"proxyName1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:123\",\"enabled\":true},{\"name\":\"proxyName2\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:124\",\"enabled\":true}]"
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithServerAndPortMapping.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/configWithServerAndPortMapping.json
@@ -6,6 +6,6 @@
     "namespace": "paas-utv"
   },
   "data": {
-    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true},{\"name\":\"proxyName1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:123\",\"enabled\":true},{\"name\":\"proxyName2\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:124\",\"enabled\":true}]"
+    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true},{\"name\":\"proxyName1\",\"listen\":\"0.0.0.0:18000\",\"upstream\":\"test1.test:123\",\"enabled\":true},{\"name\":\"proxyName2\",\"listen\":\"0.0.0.0:18001\",\"upstream\":\"test2.test:124\",\"enabled\":true},{\"name\":\"proxyName3\",\"listen\":\"0.0.0.0:18002\",\"upstream\":\"test3.test:125\",\"enabled\":false}]"
   }
 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/dcWithEndpointMapping.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/dcWithEndpointMapping.json
@@ -52,6 +52,14 @@
               {
                 "name": "URL_WITH_PATH",
                 "value": "http://localhost:18004/path"
+              },
+              {
+                "name": "INITIALLY_ENABLED",
+                "value": "http://localhost:18005"
+              },
+              {
+                "name": "INITIALLY_DISABLED",
+                "value": "http://localhost:18006"
               }
             ],
             "name": "simple"

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/dcWithServerAndPortMapping.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/ToxiproxySidecarFeatureTest/dcWithServerAndPortMapping.json
@@ -40,6 +40,14 @@
               {
                 "name": "PORT_2",
                 "value": "18001"
+              },
+              {
+                "name": "SERVER_3",
+                "value": "localhost"
+              },
+              {
+                "name": "PORT_3",
+                "value": "18002"
               }
             ],
             "name": "simple"

--- a/src/test/resources/samples/result/utv/web/configmap-toxiproxy.json
+++ b/src/test/resources/samples/result/utv/web/configmap-toxiproxy.json
@@ -24,6 +24,6 @@
     ]
   },
   "data": {
-    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\"}]"
+    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true}]"
   }
 }

--- a/src/test/resources/samples/result/utv/whoami/configmap-whoami-toxiproxy-config.json
+++ b/src/test/resources/samples/result/utv/whoami/configmap-whoami-toxiproxy-config.json
@@ -24,6 +24,6 @@
     ]
   },
   "data": {
-    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\"}]"
+    "config.json": "[{\"name\":\"app\",\"listen\":\"0.0.0.0:8090\",\"upstream\":\"0.0.0.0:8080\",\"enabled\":true}]"
   }
 }


### PR DESCRIPTION
Har lagt til et nytt felt, `initialEnabledState`, både under `endpointsFromConfig` og `serverAndPortFromConfig`, som setter verdien i `enabled` i Toxiproxy-konfigurasjonen. Tar gjerne imot andre forslag til navn på feltet, men det er viktig at det ikke forveksles med `enabled`-feltet i Aurora-konfig, som ikke er det samme som `enabled` i Toxiproxy-konfigurasjonen.