### PR TITLE
Oppdaterer Tomcat

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 version=local-SNAPSHOT
 groupId=no.skatteetaten.aurora
 artifactId=boober
+tomcat.version=9.0.58


### PR DESCRIPTION
Denne oppdateringen er nødvendig p.g.a. e [en sikkerhetsfeil](https://nvd.nist.gov/vuln/detail/CVE-2022-23181).
Den nye versjonen av Tomcat vil være inkludert i neste versjon av Spring Boot, så når den kommer, kan denne linjen fjernes igjen.