### PR TITLE
Bugfix/merge labels

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/ResourceMerger.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/service/openshift/ResourceMerger.kt
@@ -77,7 +77,7 @@ private fun updateService(mergedResource: JsonNode, existingResource: JsonNode) 
 }
 
 private fun mergeLabelsFrom(mergedResource: ObjectNode, existingResource: ObjectNode) =
-    mergedResource.updateField(existingResource, "/metadata", "labels")
+    mergedResource.mergeField(existingResource, "/metadata", "labels")
 
 private fun mergeAnnotationsFrom(mergedResource: ObjectNode, existingResource: ObjectNode) =
     mergedResource.mergeField(existingResource, "/metadata", "annotations")

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
@@ -70,11 +70,12 @@ class ResourceMergerTest : ResourceLoader() {
 
     @Test
     fun `Should preserve project labels`() {
-        val oldProject = loadJsonResource("namespace.json")
-        val newProject = loadJsonResource("namespace-new.json")
-        val merged = mergeWithExistingResource(newProject, oldProject)
+        val oldNamespace = loadJsonResource("namespace.json")
+        val newNamespace = loadJsonResource("namespace-new.json")
+        val merged = mergeWithExistingResource(newNamespace, oldNamespace)
         val labelsField = "/metadata/labels"
 
-        assertThat(merged.at(labelsField)["network.openshift.io/policy-group"]).isEqualTo(oldProject.at(labelsField)["network.openshift.io/policy-group"])
+        assertThat(merged.at(labelsField)["network.openshift.io/policy-group"]).isEqualTo(oldNamespace.at(labelsField)["network.openshift.io/policy-group"])
+        assertThat(merged.at("$labelsField/affiliation")).isEqualTo(newNamespace.at("$labelsField/affiliation"))
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/unit/ResourceMergerTest.kt
@@ -25,7 +25,7 @@ class ResourceMergerTest : ResourceLoader() {
             )
         ),
         CONFIGMAP(listOf("/metadata/resourceVersion")),
-        NAMESPACE(listOf("/metadata/annotations", "/metadata/labels")),
+        NAMESPACE(listOf("/metadata/annotations")),
         AURORACNAME(listOf("/metadata/annotations")),
         AURORAAZURECNAME(listOf("/metadata/annotations")),
     }

--- a/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/namespace-new.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/namespace-new.json
@@ -4,8 +4,7 @@
   "metadata": {
     "labels": {
       "affiliation": "paas",
-      "removeAfter": "86400",
-      "network.openshift.io/policy-group": "aup"
+      "removeAfter": "86400"
     },
     "name": "paas-utv"
   }

--- a/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/namespace.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/unit/ResourceMergerTest/namespace.json
@@ -3,7 +3,6 @@
   "kind": "Namespace",
   "metadata": {
     "labels": {
-      "affiliation": "paas",
       "removeAfter": "86400",
       "network.openshift.io/policy-group": "monitoring"
     },


### PR DESCRIPTION
Dette fikser en feil forårsaket av tidligere oppgave "preserve labels for namespace". Feilen er at ved et nytt namespace så ble ikke affiliation lagt på, på grunn av det eksisterende namespacet ikke hadde det og at jeg brukte updateField istedenfor mergeField