### PR TITLE
Bugfix/sitj 2252 clinger needs more info for groups

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("no.skatteetaten.gradle.aurora") version "4.4.14"
+    id("no.skatteetaten.gradle.aurora") version "4.4.19"
 }
 
 aurora {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -69,7 +69,7 @@ class AzureFeature(
         resources: Set<AuroraResource>,
         context: FeatureContext
     ) {
-        jwtToStsConverter.modify(adc, resources, context, this)
+        jwtToStsConverter.modify(adc, resources, context.imageMetadata, this)
     }
 
     override fun generate(adc: AuroraDeploymentSpec, context: FeatureContext): Set<AuroraResource> {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -82,6 +82,6 @@ class AzureFeature(
         fullValidation: Boolean,
         context: FeatureContext
     ): List<Exception> {
-        return auroraAzureApp.validate(adc) + auroraApim.validate(adc)
+        return auroraAzureApp.validate(adc) + auroraApim.validate(adc) + jwtToStsConverter.validate(adc)
     }
 }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -27,7 +27,7 @@ class AzureFeature(
     cantusService: CantusService,
     @Value("\${clinger.sidecar.default.version:0.4.0}") val sidecarVersion: String,
     @Value("\${clinger.sidecar.default.ldapurl:ldap://ldap.skead.no:389}") val defaultLdapUrl: String,
-    @Value("\${clinger.sidecar.default.jwks:http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys}") val defaultAzureJwks: String
+    @Value("\${clinger.sidecar.default.jwks:http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys}") val defaultAzureJwks: String
 ) : AbstractResolveTagFeature(cantusService) {
     private val jwtToStsConverter = JwtToStsConverterSubPart()
     private val auroraAzureApp = AuroraAzureAppSubPart()

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -26,7 +26,8 @@ import no.skatteetaten.aurora.boober.service.CantusService
 class AzureFeature(
     cantusService: CantusService,
     @Value("\${clinger.sidecar.default.version:0.4.0}") val sidecarVersion: String,
-    @Value("\${clinger.sidecar.default.ldapurl:ldap://ldap.skead.no:389}") val defaultLdapUrl: String
+    @Value("\${clinger.sidecar.default.ldapurl:ldap://ldap.skead.no:389}") val defaultLdapUrl: String,
+    @Value("\${clinger.sidecar.default.jwks:http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys}") val defaultAzureJwks: String
 ) : AbstractResolveTagFeature(cantusService) {
     private val jwtToStsConverter = JwtToStsConverterSubPart()
     private val auroraAzureApp = AuroraAzureAppSubPart()
@@ -41,7 +42,7 @@ class AzureFeature(
     }
 
     override fun handlers(header: AuroraDeploymentSpec, cmd: AuroraContextCommand): Set<AuroraConfigFieldHandler> {
-        return jwtToStsConverter.handlers(sidecarVersion, defaultLdapUrl) +
+        return jwtToStsConverter.handlers(sidecarVersion, defaultLdapUrl, defaultAzureJwks) +
             auroraAzureApp.handlers() +
             auroraApim.handlers(cmd.applicationFiles)
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -25,7 +25,8 @@ import no.skatteetaten.aurora.boober.service.CantusService
 @Service
 class AzureFeature(
     cantusService: CantusService,
-    @Value("\${clinger.sidecar.default.version:0.4.0}") val sidecarVersion: String
+    @Value("\${clinger.sidecar.default.version:0.4.0}") val sidecarVersion: String,
+    @Value("\${clinger.sidecar.default.ldapurl:ldap://ldap.skead.no:389}") val defaultLdapUrl: String
 ) : AbstractResolveTagFeature(cantusService) {
     private val jwtToStsConverter = JwtToStsConverterSubPart()
     private val auroraAzureApp = AuroraAzureAppSubPart()
@@ -40,7 +41,7 @@ class AzureFeature(
     }
 
     override fun handlers(header: AuroraDeploymentSpec, cmd: AuroraContextCommand): Set<AuroraConfigFieldHandler> {
-        return jwtToStsConverter.handlers(sidecarVersion) +
+        return jwtToStsConverter.handlers(sidecarVersion, defaultLdapUrl) +
             auroraAzureApp.handlers() +
             auroraApim.handlers(cmd.applicationFiles)
     }

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -26,8 +26,8 @@ import no.skatteetaten.aurora.boober.service.CantusService
 class AzureFeature(
     cantusService: CantusService,
     @Value("\${clinger.sidecar.default.version:0}") val sidecarVersion: String,
-    @Value("\${clinger.sidecar.default.ldapurl:}") val defaultLdapUrl: String,
-    @Value("\${clinger.sidecar.default.jwks:http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys}") val defaultAzureJwks: String
+    @Value("\${clinger.sidecar.default.ldapurl}") val defaultLdapUrl: String,
+    @Value("\${clinger.sidecar.default.jwks}") val defaultAzureJwks: String
 ) : AbstractResolveTagFeature(cantusService) {
     private val jwtToStsConverter = JwtToStsConverterSubPart()
     private val auroraAzureApp = AuroraAzureAppSubPart()

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/AzureFeature.kt
@@ -25,8 +25,8 @@ import no.skatteetaten.aurora.boober.service.CantusService
 @Service
 class AzureFeature(
     cantusService: CantusService,
-    @Value("\${clinger.sidecar.default.version:0.4.0}") val sidecarVersion: String,
-    @Value("\${clinger.sidecar.default.ldapurl:ldap://ldap.skead.no:389}") val defaultLdapUrl: String,
+    @Value("\${clinger.sidecar.default.version:0}") val sidecarVersion: String,
+    @Value("\${clinger.sidecar.default.ldapurl:}") val defaultLdapUrl: String,
     @Value("\${clinger.sidecar.default.jwks:http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys}") val defaultAzureJwks: String
 ) : AbstractResolveTagFeature(cantusService) {
     private val jwtToStsConverter = JwtToStsConverterSubPart()

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -109,7 +109,6 @@ class JwtToStsConverterSubPart {
                 )
             }
             image = imageMetadata.getFullImagePath()
-            imagePullPolicy = "Always"
             readinessProbe = newProbe {
                 httpGet {
                     path = "/ready"

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -206,7 +206,7 @@ class JwtToStsConverterSubPart {
             .build()
     }
 
-    fun handlers(sidecarVersion: String, defaultLdapUrl: String): Set<AuroraConfigFieldHandler> =
+    fun handlers(sidecarVersion: String, defaultLdapUrl: String, defaultAzureJwks: String): Set<AuroraConfigFieldHandler> =
         setOf(
             AuroraConfigFieldHandler(
                 ConfigPath.enabled,
@@ -219,6 +219,7 @@ class JwtToStsConverterSubPart {
             ),
             AuroraConfigFieldHandler(
                 ConfigPath.discoveryUrl,
+                defaultValue = defaultAzureJwks,
                 validator = { it.validUrl(required = false) }
             ),
 

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -109,6 +109,7 @@ class JwtToStsConverterSubPart {
                 )
             }
             image = imageMetadata.getFullImagePath()
+            imagePullPolicy = "Always"
             readinessProbe = newProbe {
                 httpGet {
                     path = "/ready"

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -87,7 +87,7 @@ class JwtToStsConverterSubPart {
         )
 
         return newContainer {
-            name = "${adc.name}-clinger-mix" // Not naming it sidecar, as that will mask out secrets
+            name = "${adc.name}-clinger-sidecar"
             ports = containerPorts.map {
                 newContainerPort {
                     name = it.key

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -76,10 +76,6 @@ class JwtToStsConverterSubPart {
                 }
 
                 parent.modifyResource(it, "Changed targetPort to point to clinger")
-            } else if (it.resource.kind == "Secret") {
-                if (adc.isIvGroupsEnabled && it.resource.metadata.name == adc.getOrNull(ConfigPath.ldapUserSecretRef)) {
-                    parent.modifyResource(it, "added LDAP secret ref from ${it.resource.metadata.name}")
-                }
             }
         }
     }
@@ -170,12 +166,15 @@ class JwtToStsConverterSubPart {
         ).addIf(
             adc.isIvGroupsEnabled,
             listOf(
-                createSecretRef("CLINGER_LDAP_USERNAME", adc[ConfigPath.ldapUserSecretRef], "ldap.username"),
-                createSecretRef("CLINGER_LDAP_PASSWORD", adc[ConfigPath.ldapUserSecretRef], "ldap.password"),
+                createSecretRef("CLINGER_LDAP_USERNAME", secretName(adc), "azure.ldap.username"),
+                createSecretRef("CLINGER_LDAP_PASSWORD", secretName(adc), "azure.ldap.password"),
                 createEnvOrNull("CLINGER_LDAP_ADDRESS", adc[ConfigPath.ldapUrl])
             )
         )
     }
+
+    private fun secretName(adc: AuroraDeploymentSpec): String =
+        "${adc.name}-${adc.get<String>(ConfigPath.ldapUserSecretRef)}-vault"
 
     private fun createEnvOrNull(name: String, value: String?): EnvVar? {
         return if (value == null) {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -42,7 +42,7 @@ class JwtToStsConverterSubPart {
         private const val root = "azure/jwtToStsConverter"
         const val enabled = "$root/enabled"
         const val version = "$root/version"
-        const val discoveryUrl = "$root/discoveryUrl"
+        const val jwksUrl = "$root/jwksUrl"
         const val ivGroupsRequired = "$root/ivGroupsRequired"
         const val ldapUserVaultName = "$root/ldapUserVaultName"
         const val ldapUrl = "$root/ldapUrl"
@@ -161,7 +161,9 @@ class JwtToStsConverterSubPart {
                 createEnvRef(name = "POD_NAME", apiVersion = "v1", fieldPath = "metadata.name")
             )
         ).addIfNotNull(
-            createEnvOrNull("CLINGER_DISCOVERY_URL", adc.getOrNull<String>(ConfigPath.discoveryUrl))
+            createEnvOrNull("CLINGER_DISCOVERY_URL", adc.getOrNull<String>(ConfigPath.jwksUrl))
+        ).addIfNotNull(
+            createEnvOrNull("CLINGER_JWKS_URL", adc.getOrNull<String>(ConfigPath.jwksUrl))
         ).addIfNotNull(
             createEnvOrNull("CLINGER_IV_GROUPS_REQUIRED", adc.getOrNull<String>(ConfigPath.ivGroupsRequired))
         ).addIf(
@@ -239,11 +241,10 @@ class JwtToStsConverterSubPart {
                 defaultValue = sidecarVersion
             ),
             AuroraConfigFieldHandler(
-                ConfigPath.discoveryUrl,
+                ConfigPath.jwksUrl,
                 defaultValue = defaultAzureJwks,
                 validator = { it.validUrl(required = false) }
             ),
-
             AuroraConfigFieldHandler(
                 ConfigPath.ivGroupsRequired,
                 defaultValue = false,

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -34,7 +34,7 @@ val AuroraDeploymentSpec.isJwtToStsConverterEnabled: Boolean
 val AuroraDeploymentSpec.isIvGroupsEnabled: Boolean
     get() = (this.getOrNull(JwtToStsConverterSubPart.ConfigPath.ivGroupsRequired) ?: false) &&
         (this.getOrNull<String>(JwtToStsConverterSubPart.ConfigPath.ldapUrl) != null) &&
-        (this.getOrNull<String>(JwtToStsConverterSubPart.ConfigPath.ldapUserSecretRef) != null)
+        (this.getOrNull<String>(JwtToStsConverterSubPart.ConfigPath.ldapUserVaultName) != null)
 
 class JwtToStsConverterSubPart {
     object ConfigPath {
@@ -43,7 +43,7 @@ class JwtToStsConverterSubPart {
         const val version = "$root/version"
         const val discoveryUrl = "$root/discoveryUrl"
         const val ivGroupsRequired = "$root/ivGroupsRequired"
-        const val ldapUserSecretRef = "$root/ldapUserSecretRef"
+        const val ldapUserVaultName = "$root/ldapUserVaultName"
         const val ldapUrl = "$root/ldapUrl"
     }
 
@@ -174,7 +174,7 @@ class JwtToStsConverterSubPart {
     }
 
     private fun secretName(adc: AuroraDeploymentSpec): String =
-        "${adc.name}-${adc.get<String>(ConfigPath.ldapUserSecretRef)}-vault"
+        "${adc.name}-${adc.get<String>(ConfigPath.ldapUserVaultName)}-vault"
 
     private fun createEnvOrNull(name: String, value: String?): EnvVar? {
         return if (value == null) {
@@ -229,7 +229,7 @@ class JwtToStsConverterSubPart {
                 validator = { it.boolean() }
             ),
             AuroraConfigFieldHandler(
-                ConfigPath.ldapUserSecretRef,
+                ConfigPath.ldapUserVaultName,
                 defaultValue = ""
             ),
             AuroraConfigFieldHandler(

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/azure/JwtToStsConverterSubPart.kt
@@ -22,6 +22,7 @@ import no.skatteetaten.aurora.boober.model.AuroraConfigFieldHandler
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.model.AuroraResource
 import no.skatteetaten.aurora.boober.model.PortNumbers
+import no.skatteetaten.aurora.boober.service.AuroraDeploymentSpecValidationException
 import no.skatteetaten.aurora.boober.service.ImageMetadata
 import no.skatteetaten.aurora.boober.utils.addIf
 import no.skatteetaten.aurora.boober.utils.addIfNotNull
@@ -204,6 +205,26 @@ class JwtToStsConverterSubPart {
                 )
             )
             .build()
+    }
+
+    fun validate(
+        adc: AuroraDeploymentSpec
+    ): List<Exception> {
+        val errors = mutableListOf<Exception>()
+        if (adc.isIvGroupsEnabled &&
+            (
+                adc.getOrNull<String>(ConfigPath.ldapUserVaultName) == null ||
+                    adc.getOrNull<String>(ConfigPath.ldapUrl) == null
+                )
+        ) {
+            errors.add(
+                AuroraDeploymentSpecValidationException(
+                    "You need to specify ${ConfigPath.ldapUrl} and ${ConfigPath.ldapUserVaultName} when you set ${ConfigPath.ivGroupsRequired}"
+                )
+            )
+        }
+
+        return errors
     }
 
     fun handlers(sidecarVersion: String, defaultLdapUrl: String, defaultAzureJwks: String): Set<AuroraConfigFieldHandler> =

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
@@ -15,7 +15,7 @@ import no.skatteetaten.aurora.boober.utils.AbstractMultiFeatureTest
 class AuroraAzureApimSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
-            AzureFeature(cantusService, "0.4.0")
+            AzureFeature(cantusService, "0.4.0", "ldap://default")
         )
 
     private val cantusService: CantusService = mockk()

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
@@ -295,7 +295,7 @@ class AuroraAzureApimSubPartTest : AbstractMultiFeatureTest() {
                 "azureAppFqdn": "saksmappa.amutv.skead.no",
                 "groups": [],
                 "jwtToStsConverter": {
-                  "discoveryUrl": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
+                  "jwksUrl": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
                   "enabled": true,
                   "version": "0"
                 },

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
@@ -15,7 +15,7 @@ import no.skatteetaten.aurora.boober.utils.AbstractMultiFeatureTest
 class AuroraAzureApimSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
-            AzureFeature(cantusService, "0.4.0", "ldap://default", "http://jwks")
+            AzureFeature(cantusService, "0", "ldap://default", "http://jwks")
         )
 
     private val cantusService: CantusService = mockk()
@@ -24,12 +24,12 @@ class AuroraAzureApimSubPartTest : AbstractMultiFeatureTest() {
     fun setupMock() {
         every {
             cantusService.getImageMetadata(
-                "no_skatteetaten_aurora", "clinger", "0.4.0"
+                "no_skatteetaten_aurora", "clinger", "0"
             )
         } returns
             ImageMetadata(
                 "docker.registry/no_skatteetaten_aurora/clinger",
-                "0.4.0",
+                "0",
                 "sha:1234567"
             )
     }
@@ -297,7 +297,7 @@ class AuroraAzureApimSubPartTest : AbstractMultiFeatureTest() {
                 "jwtToStsConverter": {
                   "discoveryUrl": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
                   "enabled": true,
-                  "version": "0.4.0"
+                  "version": "0"
                 },
                 "apim": {
                   "enabled"  : true,

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
@@ -15,7 +15,7 @@ import no.skatteetaten.aurora.boober.utils.AbstractMultiFeatureTest
 class AuroraAzureApimSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
-            AzureFeature(cantusService, "0.4.0", "ldap://default")
+            AzureFeature(cantusService, "0.4.0", "ldap://default", "http://jwks")
         )
 
     private val cantusService: CantusService = mockk()

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureApimSubPartTest.kt
@@ -295,7 +295,7 @@ class AuroraAzureApimSubPartTest : AbstractMultiFeatureTest() {
                 "azureAppFqdn": "saksmappa.amutv.skead.no",
                 "groups": [],
                 "jwtToStsConverter": {
-                  "discoveryUrl": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+                  "discoveryUrl": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
                   "enabled": true,
                   "version": "0.4.0"
                 },

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
@@ -17,7 +17,7 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
             WebsealFeature(".test.skead.no"),
-            AzureFeature(cantusService, "0.4.0", "ldap://default")
+            AzureFeature(cantusService, "0.4.0", "ldap://default", "http://jwks")
         )
 
     private val cantusService: CantusService = mockk()

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
@@ -17,7 +17,7 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
             WebsealFeature(".test.skead.no"),
-            AzureFeature(cantusService, "0.4.0", "ldap://default", "http://jwks")
+            AzureFeature(cantusService, "0", "ldap://default", "http://jwks")
         )
 
     private val cantusService: CantusService = mockk()
@@ -26,12 +26,12 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
     fun setupMock() {
         every {
             cantusService.getImageMetadata(
-                "no_skatteetaten_aurora", "clinger", "0.4.0"
+                "no_skatteetaten_aurora", "clinger", "0"
             )
         } returns
             ImageMetadata(
                 "docker.registry/no_skatteetaten_aurora/clinger",
-                "0.4.0",
+                "0",
                 "sha:1234567"
             )
     }
@@ -79,9 +79,7 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
                 "azureAppFqdn": "saksmappa.amutv.skead.no",
                 "groups": [],
                 "jwtToStsConverter": {
-                  "discoveryUrl": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
-                  "enabled": true,
-                  "version": "0.4.0"
+                  "enabled": true
                 }
               }
         }""",

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
@@ -17,7 +17,7 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
             WebsealFeature(".test.skead.no"),
-            AzureFeature(cantusService, "0.4.0")
+            AzureFeature(cantusService, "0.4.0", "ldap://default")
         )
 
     private val cantusService: CantusService = mockk()

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/AuroraAzureAppSubPartTest.kt
@@ -79,7 +79,7 @@ class AuroraAzureAppSubPartTest : AbstractMultiFeatureTest() {
                 "azureAppFqdn": "saksmappa.amutv.skead.no",
                 "groups": [],
                 "jwtToStsConverter": {
-                  "discoveryUrl": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+                  "discoveryUrl": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
                   "enabled": true,
                   "version": "0.4.0"
                 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test
 class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
-            AzureFeature(cantusService, "0.4.0", "ldap://default", "http://jwks"),
+            AzureFeature(cantusService, "0", "ldap://default", "http://jwks"),
             WebsealFeature(".test.skead.no")
         )
 
@@ -29,12 +29,12 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
     fun setupMock() {
         every {
             cantusService.getImageMetadata(
-                "no_skatteetaten_aurora", "clinger", "0.4.0"
+                "no_skatteetaten_aurora", "clinger", "0"
             )
         } returns
             ImageMetadata(
                 "docker.registry/no_skatteetaten_aurora/clinger",
-                "0.4.0",
+                "0",
                 "sha:1234567"
             )
         every {
@@ -80,7 +80,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
              "azure" : {
                 "jwtToStsConverter": {
                     "enabled": true,
-                    "version": "0.4.0", 
+                    "version": "0", 
                     "discoveryUrl": "https://endpoint",
                     "ivGroupsRequired": "false"
                 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
@@ -61,7 +61,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
              "azure" : {
                 "jwtToStsConverter": {
                     "enabled": true,
-                    "discoveryUrl": "https://endpoint",
+                    "jwksUrl": "https://endpoint",
                     "ivGroupsRequired": "false"
                 }
               }
@@ -81,7 +81,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
                 "jwtToStsConverter": {
                     "enabled": true,
                     "version": "0", 
-                    "discoveryUrl": "https://endpoint",
+                    "jwksUrl": "https://endpoint",
                     "ivGroupsRequired": "false"
                 }
               }
@@ -109,7 +109,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
                 "jwtToStsConverter": {
                     "enabled": true,
                     "version": "0.3.2", 
-                    "discoveryUrl": "https://endpoint",
+                    "jwksUrl": "https://endpoint",
                     "ivGroupsRequired": "false"
                 }
               }
@@ -155,7 +155,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
                 "groups": [],
                 "jwtToStsConverter": {
                     "enabled": true,
-                    "discoveryUrl": "https://endpoint"
+                    "jwksUrl": "https://endpoint"
                 }
               }
            }""",
@@ -175,7 +175,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
              "azure" : {
                 "jwtToStsConverter": {
                     "enabled": true,
-                    "discoveryUrl": "https://endpoint"
+                    "jwksUrl": "https://endpoint"
                 }
               }
            }""",
@@ -195,7 +195,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
              "azure" : {
                 "jwtToStsConverter": {
                     "enabled": true,
-                    "discoveryUrl": "https://endpoint",
+                    "jwksUrl": "https://endpoint",
                     "ivGroupsRequired": true,
                     "ldapUserVaultName": "foo"
                 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
@@ -197,7 +197,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
                     "enabled": true,
                     "discoveryUrl": "https://endpoint",
                     "ivGroupsRequired": true,
-                    "ldapUserSecretRef": "foo"
+                    "ldapUserVaultName": "foo"
                 }
               }
            }""",

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
@@ -197,7 +197,7 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
                     "enabled": true,
                     "discoveryUrl": "https://endpoint",
                     "ivGroupsRequired": true,
-                    "ldapUserSecretRef": "foo-vault"
+                    "ldapUserSecretRef": "foo"
                 }
               }
            }""",

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test
 class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
-            AzureFeature(cantusService, "0.4.0"),
+            AzureFeature(cantusService, "0.4.0", "ldap://default"),
             WebsealFeature(".test.skead.no")
         )
 
@@ -185,5 +185,26 @@ class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
         assertThat(dcResource).auroraResourceModifiedByThisFeatureWithComment("Added clinger sidecar container")
             .auroraResourceMatchesFile("dc-webseal-true.json")
         assertThat(webseal).auroraResourceMatchesFile("webseal-route.json")
+    }
+
+    @Test
+    fun `clinger can have iv-groups enabled`() {
+
+        val (_, dcResource) = modifyResources(
+            """{
+             "azure" : {
+                "jwtToStsConverter": {
+                    "enabled": true,
+                    "discoveryUrl": "https://endpoint",
+                    "ivGroupsRequired": true,
+                    "ldapUserSecretRef": "foo-vault"
+                }
+              }
+           }""",
+            createEmptyService(), createEmptyDeploymentConfig()
+        )
+
+        assertThat(dcResource).auroraResourceModifiedByThisFeatureWithComment("Added clinger sidecar container")
+            .auroraResourceMatchesFile("dc-ivgroups-true.json")
     }
 }

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test
 class JwtToStsConverterSubPartTest : AbstractMultiFeatureTest() {
     override val features: List<Feature>
         get() = listOf(
-            AzureFeature(cantusService, "0.4.0", "ldap://default"),
+            AzureFeature(cantusService, "0.4.0", "ldap://default", "http://jwks"),
             WebsealFeature(".test.skead.no")
         )
 

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/utils/ResourceLoader.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/utils/ResourceLoader.kt
@@ -117,7 +117,7 @@ open class ResourceLoader {
                     allowOverwrite = false
                 )
             } else {
-                this.fail(actual, expected)
+                this.fail(expected, actual)
             }
         }
     }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -103,6 +103,12 @@ boober:
         suffix: ".test.webseal"
     productionlevel: "u"
 
+clinger:
+    sidecar:
+        default:
+            jwks: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+            ldapurl: ""
+
 auroraconfig:
     builder:
         version: "1"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
@@ -555,6 +555,16 @@
           }
         ]
       },
+      "discoveryUrl": {
+        "source": "default",
+        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "sources": [
+          {
+            "name": "default",
+            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+          }
+        ]
+      },
       "ivGroupsRequired": {
         "source": "default",
         "value": false,

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
@@ -575,7 +575,7 @@
           }
         ]
       },
-      "ldapUserSecretRef": {
+      "ldapUserVaultName": {
         "source": "default",
         "value": "",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
@@ -557,11 +557,11 @@
       },
       "discoveryUrl": {
         "source": "default",
-        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [
           {
             "name": "default",
-            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+            "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
           }
         ]
       },

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
@@ -564,6 +564,26 @@
             "value": false
           }
         ]
+      },
+      "ldapUserSecretRef": {
+        "source": "default",
+        "value": "",
+        "sources": [
+          {
+            "name": "default",
+            "value": ""
+          }
+        ]
+      },
+      "ldapUrl": {
+        "source": "default",
+        "value": "ldap://ldap.skead.no:389",
+        "sources": [
+          {
+            "name": "default",
+            "value": "ldap://ldap.skead.no:389"
+          }
+        ]
       }
     },
     "managedRoute": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
@@ -555,7 +555,7 @@
           }
         ]
       },
-      "discoveryUrl": {
+      "jwksUrl": {
         "source": "default",
         "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.json
@@ -547,11 +547,11 @@
       },
       "version": {
         "source": "default",
-        "value": "0.4.0",
+        "value": "0",
         "sources": [
           {
             "name": "default",
-            "value": "0.4.0"
+            "value": "0"
           }
         ]
       },
@@ -587,11 +587,11 @@
       },
       "ldapUrl": {
         "source": "default",
-        "value": "ldap://ldap.skead.no:389",
+        "value": "",
         "sources": [
           {
             "name": "default",
-            "value": "ldap://ldap.skead.no:389"
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
@@ -65,7 +65,7 @@ utv/about.json | cluster: "utv"
        default |     version: "0.4.0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
-       default |     ldapUserSecretRef: ""
+       default |     ldapUserVaultName: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
@@ -64,6 +64,8 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |     ldapUserSecretRef: ""
+       default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
@@ -63,7 +63,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
@@ -62,11 +62,11 @@ utv/about.json | cluster: "utv"
                | azure:
                |   jwtToStsConverter:
        default |     enabled: false
-       default |     version: "0.4.0"
+       default |     version: "0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
-       default |     ldapUrl: "ldap://ldap.skead.no:389"
+       default |     ldapUrl: ""
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
@@ -63,7 +63,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+       default |     jwksUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
        default |     ldapUrl: ""

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/ah-spec-default.txt
@@ -63,6 +63,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -1461,6 +1461,16 @@
           }
         ]
       },
+      "discoveryUrl": {
+        "source": "default",
+        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "sources": [
+          {
+            "name": "default",
+            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+          }
+        ]
+      },
       "ivGroupsRequired": {
         "source": "default",
         "value": false,

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -1470,6 +1470,26 @@
             "value": false
           }
         ]
+      },
+      "ldapUserSecretRef": {
+        "source": "default",
+        "value": "",
+        "sources": [
+          {
+            "name": "default",
+            "value": ""
+          }
+        ]
+      },
+      "ldapUrl": {
+        "source": "default",
+        "value": "ldap://ldap.skead.no:389",
+        "sources": [
+          {
+            "name": "default",
+            "value": "ldap://ldap.skead.no:389"
+          }
+        ]
       }
     },
     "managedRoute": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -1453,11 +1453,11 @@
       },
       "version": {
         "source": "default",
-        "value": "0.4.0",
+        "value": "0",
         "sources": [
           {
             "name": "default",
-            "value": "0.4.0"
+            "value": "0"
           }
         ]
       },
@@ -1493,11 +1493,11 @@
       },
       "ldapUrl": {
         "source": "default",
-        "value": "ldap://ldap.skead.no:389",
+        "value": "",
         "sources": [
           {
             "name": "default",
-            "value": "ldap://ldap.skead.no:389"
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -1481,7 +1481,7 @@
           }
         ]
       },
-      "ldapUserSecretRef": {
+      "ldapUserVaultName": {
         "source": "default",
         "value": "",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -1461,7 +1461,7 @@
           }
         ]
       },
-      "discoveryUrl": {
+      "jwksUrl": {
         "source": "default",
         "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -1463,11 +1463,11 @@
       },
       "discoveryUrl": {
         "source": "default",
-        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [
           {
             "name": "default",
-            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+            "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
           }
         ]
       },

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -165,6 +165,7 @@ utv/about-alternate.json |   ttl: "1d"
                          |   jwtToStsConverter:
                  default |     enabled: false
                  default |     version: "0.4.0"
+                 default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
                  default |     ivGroupsRequired: false
                  default |     ldapUserSecretRef: ""
                  default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -167,7 +167,7 @@ utv/about-alternate.json |   ttl: "1d"
                  default |     version: "0.4.0"
                  default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
                  default |     ivGroupsRequired: false
-                 default |     ldapUserSecretRef: ""
+                 default |     ldapUserVaultName: ""
                  default |     ldapUrl: "ldap://ldap.skead.no:389"
                  default |   managedRoute: false
                          |   apim:

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -166,6 +166,8 @@ utv/about-alternate.json |   ttl: "1d"
                  default |     enabled: false
                  default |     version: "0.4.0"
                  default |     ivGroupsRequired: false
+                 default |     ldapUserSecretRef: ""
+                 default |     ldapUrl: "ldap://ldap.skead.no:389"
                  default |   managedRoute: false
                          |   apim:
                  default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -165,7 +165,7 @@ utv/about-alternate.json |   ttl: "1d"
                          |   jwtToStsConverter:
                  default |     enabled: false
                  default |     version: "0"
-                 default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+                 default |     jwksUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
                  default |     ivGroupsRequired: false
                  default |     ldapUserVaultName: ""
                  default |     ldapUrl: ""

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -165,7 +165,7 @@ utv/about-alternate.json |   ttl: "1d"
                          |   jwtToStsConverter:
                  default |     enabled: false
                  default |     version: "0.4.0"
-                 default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+                 default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
                  default |     ivGroupsRequired: false
                  default |     ldapUserSecretRef: ""
                  default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -164,11 +164,11 @@ utv/about-alternate.json |   ttl: "1d"
                          | azure:
                          |   jwtToStsConverter:
                  default |     enabled: false
-                 default |     version: "0.4.0"
+                 default |     version: "0"
                  default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
                  default |     ivGroupsRequired: false
                  default |     ldapUserVaultName: ""
-                 default |     ldapUrl: "ldap://ldap.skead.no:389"
+                 default |     ldapUrl: ""
                  default |   managedRoute: false
                          |   apim:
                  default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
@@ -759,11 +759,11 @@
       },
       "discoveryUrl": {
         "source": "default",
-        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [
           {
             "name": "default",
-            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+            "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
           }
         ]
       },

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
@@ -766,6 +766,26 @@
             "value": false
           }
         ]
+      },
+      "ldapUserSecretRef": {
+        "source": "default",
+        "value": "",
+        "sources": [
+          {
+            "name": "default",
+            "value": ""
+          }
+        ]
+      },
+      "ldapUrl": {
+        "source": "default",
+        "value": "ldap://ldap.skead.no:389",
+        "sources": [
+          {
+            "name": "default",
+            "value": "ldap://ldap.skead.no:389"
+          }
+        ]
       }
     },
     "managedRoute": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
@@ -749,11 +749,11 @@
       },
       "version": {
         "source": "default",
-        "value": "0.4.0",
+        "value": "0",
         "sources": [
           {
             "name": "default",
-            "value": "0.4.0"
+            "value": "0"
           }
         ]
       },
@@ -789,11 +789,11 @@
       },
       "ldapUrl": {
         "source": "default",
-        "value": "ldap://ldap.skead.no:389",
+        "value": "",
         "sources": [
           {
             "name": "default",
-            "value": "ldap://ldap.skead.no:389"
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
@@ -757,7 +757,7 @@
           }
         ]
       },
-      "discoveryUrl": {
+      "jwksUrl": {
         "source": "default",
         "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
@@ -757,6 +757,16 @@
           }
         ]
       },
+      "discoveryUrl": {
+        "source": "default",
+        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "sources": [
+          {
+            "name": "default",
+            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+          }
+        ]
+      },
       "ivGroupsRequired": {
         "source": "default",
         "value": false,

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.json
@@ -777,7 +777,7 @@
           }
         ]
       },
-      "ldapUserSecretRef": {
+      "ldapUserVaultName": {
         "source": "default",
         "value": "",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
@@ -73,7 +73,7 @@ utv/python.json | sts: true
         default |     version: "0.4.0"
         default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
         default |     ivGroupsRequired: false
-        default |     ldapUserSecretRef: ""
+        default |     ldapUserVaultName: ""
         default |     ldapUrl: "ldap://ldap.skead.no:389"
         default |   managedRoute: false
                 |   apim:

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
@@ -71,6 +71,7 @@ utv/python.json | sts: true
                 |   jwtToStsConverter:
         default |     enabled: false
         default |     version: "0.4.0"
+        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
         default |     ivGroupsRequired: false
         default |     ldapUserSecretRef: ""
         default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
@@ -72,6 +72,8 @@ utv/python.json | sts: true
         default |     enabled: false
         default |     version: "0.4.0"
         default |     ivGroupsRequired: false
+        default |     ldapUserSecretRef: ""
+        default |     ldapUrl: "ldap://ldap.skead.no:389"
         default |   managedRoute: false
                 |   apim:
         default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
@@ -70,11 +70,11 @@ utv/python.json | sts: true
                 | azure:
                 |   jwtToStsConverter:
         default |     enabled: false
-        default |     version: "0.4.0"
+        default |     version: "0"
         default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
         default |     ivGroupsRequired: false
         default |     ldapUserVaultName: ""
-        default |     ldapUrl: "ldap://ldap.skead.no:389"
+        default |     ldapUrl: ""
         default |   managedRoute: false
                 |   apim:
         default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
@@ -71,7 +71,7 @@ utv/python.json | sts: true
                 |   jwtToStsConverter:
         default |     enabled: false
         default |     version: "0"
-        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+        default |     jwksUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
         default |     ivGroupsRequired: false
         default |     ldapUserVaultName: ""
         default |     ldapUrl: ""

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/python-spec-default.txt
@@ -71,7 +71,7 @@ utv/python.json | sts: true
                 |   jwtToStsConverter:
         default |     enabled: false
         default |     version: "0.4.0"
-        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
         default |     ivGroupsRequired: false
         default |     ldapUserSecretRef: ""
         default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
@@ -718,6 +718,26 @@
             "value": false
           }
         ]
+      },
+      "ldapUserSecretRef": {
+        "source": "default",
+        "value": "",
+        "sources": [
+          {
+            "name": "default",
+            "value": ""
+          }
+        ]
+      },
+      "ldapUrl": {
+        "source": "default",
+        "value": "ldap://ldap.skead.no:389",
+        "sources": [
+          {
+            "name": "default",
+            "value": "ldap://ldap.skead.no:389"
+          }
+        ]
       }
     },
     "managedRoute": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
@@ -709,7 +709,7 @@
           }
         ]
       },
-      "discoveryUrl": {
+      "jwksUrl": {
         "source": "default",
         "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
@@ -709,6 +709,16 @@
           }
         ]
       },
+      "discoveryUrl": {
+        "source": "default",
+        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "sources": [
+          {
+            "name": "default",
+            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+          }
+        ]
+      },
       "ivGroupsRequired": {
         "source": "default",
         "value": false,

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
@@ -701,11 +701,11 @@
       },
       "version": {
         "source": "default",
-        "value": "0.4.0",
+        "value": "0",
         "sources": [
           {
             "name": "default",
-            "value": "0.4.0"
+            "value": "0"
           }
         ]
       },
@@ -741,11 +741,11 @@
       },
       "ldapUrl": {
         "source": "default",
-        "value": "ldap://ldap.skead.no:389",
+        "value": "",
         "sources": [
           {
             "name": "default",
-            "value": "ldap://ldap.skead.no:389"
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
@@ -729,7 +729,7 @@
           }
         ]
       },
-      "ldapUserSecretRef": {
+      "ldapUserVaultName": {
         "source": "default",
         "value": "",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.json
@@ -711,11 +711,11 @@
       },
       "discoveryUrl": {
         "source": "default",
-        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [
           {
             "name": "default",
-            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+            "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
           }
         ]
       },

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
@@ -73,7 +73,7 @@ utv/about.json | cluster: "utv"
        default |     version: "0.4.0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
-       default |     ldapUserSecretRef: ""
+       default |     ldapUserVaultName: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
@@ -71,6 +71,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
@@ -72,6 +72,8 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |     ldapUserSecretRef: ""
+       default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
@@ -71,7 +71,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+       default |     jwksUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
        default |     ldapUrl: ""

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
@@ -71,7 +71,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/simple-spec-default.txt
@@ -70,11 +70,11 @@ utv/about.json | cluster: "utv"
                | azure:
                |   jwtToStsConverter:
        default |     enabled: false
-       default |     version: "0.4.0"
+       default |     version: "0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
-       default |     ldapUrl: "ldap://ldap.skead.no:389"
+       default |     ldapUrl: ""
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
@@ -543,7 +543,7 @@
           }
         ]
       },
-      "discoveryUrl": {
+      "jwksUrl": {
         "source": "default",
         "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
@@ -545,11 +545,11 @@
       },
       "discoveryUrl": {
         "source": "default",
-        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [
           {
             "name": "default",
-            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+            "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
           }
         ]
       },

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
@@ -563,7 +563,7 @@
           }
         ]
       },
-      "ldapUserSecretRef": {
+      "ldapUserVaultName": {
         "source": "default",
         "value": "",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
@@ -543,6 +543,16 @@
           }
         ]
       },
+      "discoveryUrl": {
+        "source": "default",
+        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "sources": [
+          {
+            "name": "default",
+            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+          }
+        ]
+      },
       "ivGroupsRequired": {
         "source": "default",
         "value": false,

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
@@ -535,11 +535,11 @@
       },
       "version": {
         "source": "default",
-        "value": "0.4.0",
+        "value": "0",
         "sources": [
           {
             "name": "default",
-            "value": "0.4.0"
+            "value": "0"
           }
         ]
       },
@@ -575,11 +575,11 @@
       },
       "ldapUrl": {
         "source": "default",
-        "value": "ldap://ldap.skead.no:389",
+        "value": "",
         "sources": [
           {
             "name": "default",
-            "value": "ldap://ldap.skead.no:389"
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.json
@@ -552,6 +552,26 @@
             "value": false
           }
         ]
+      },
+      "ldapUserSecretRef": {
+        "source": "default",
+        "value": "",
+        "sources": [
+          {
+            "name": "default",
+            "value": ""
+          }
+        ]
+      },
+      "ldapUrl": {
+        "source": "default",
+        "value": "ldap://ldap.skead.no:389",
+        "sources": [
+          {
+            "name": "default",
+            "value": "ldap://ldap.skead.no:389"
+          }
+        ]
       }
     },
     "managedRoute": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
@@ -61,7 +61,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+       default |     jwksUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
        default |     ldapUrl: ""

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
@@ -61,7 +61,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
@@ -61,6 +61,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
@@ -60,11 +60,11 @@ utv/about.json | cluster: "utv"
                | azure:
                |   jwtToStsConverter:
        default |     enabled: false
-       default |     version: "0.4.0"
+       default |     version: "0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
-       default |     ldapUrl: "ldap://ldap.skead.no:389"
+       default |     ldapUrl: ""
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
@@ -63,7 +63,7 @@ utv/about.json | cluster: "utv"
        default |     version: "0.4.0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
-       default |     ldapUserSecretRef: ""
+       default |     ldapUserVaultName: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/template-spec-default.txt
@@ -62,6 +62,8 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |     ldapUserSecretRef: ""
+       default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
@@ -775,6 +775,16 @@
           }
         ]
       },
+      "discoveryUrl": {
+        "source": "default",
+        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "sources": [
+          {
+            "name": "default",
+            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+          }
+        ]
+      },
       "ivGroupsRequired": {
         "source": "default",
         "value": false,

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
@@ -777,11 +777,11 @@
       },
       "discoveryUrl": {
         "source": "default",
-        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [
           {
             "name": "default",
-            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+            "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
           }
         ]
       },

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
@@ -767,11 +767,11 @@
       },
       "version": {
         "source": "default",
-        "value": "0.4.0",
+        "value": "0",
         "sources": [
           {
             "name": "default",
-            "value": "0.4.0"
+            "value": "0"
           }
         ]
       },
@@ -807,11 +807,11 @@
       },
       "ldapUrl": {
         "source": "default",
-        "value": "ldap://ldap.skead.no:389",
+        "value": "",
         "sources": [
           {
             "name": "default",
-            "value": "ldap://ldap.skead.no:389"
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
@@ -784,6 +784,26 @@
             "value": false
           }
         ]
+      },
+      "ldapUserSecretRef": {
+        "source": "default",
+        "value": "",
+        "sources": [
+          {
+            "name": "default",
+            "value": ""
+          }
+        ]
+      },
+      "ldapUrl": {
+        "source": "default",
+        "value": "ldap://ldap.skead.no:389",
+        "sources": [
+          {
+            "name": "default",
+            "value": "ldap://ldap.skead.no:389"
+          }
+        ]
       }
     },
     "managedRoute": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
@@ -775,7 +775,7 @@
           }
         ]
       },
-      "discoveryUrl": {
+      "jwksUrl": {
         "source": "default",
         "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.json
@@ -795,7 +795,7 @@
           }
         ]
       },
-      "ldapUserSecretRef": {
+      "ldapUserVaultName": {
         "source": "default",
         "value": "",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
@@ -80,7 +80,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+       default |     jwksUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
        default |     ldapUrl: ""

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
@@ -80,7 +80,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
@@ -82,7 +82,7 @@ utv/about.json | cluster: "utv"
        default |     version: "0.4.0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
-       default |     ldapUserSecretRef: ""
+       default |     ldapUserVaultName: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
@@ -81,6 +81,8 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |     ldapUserSecretRef: ""
+       default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
@@ -79,11 +79,11 @@ utv/about.json | cluster: "utv"
                | azure:
                |   jwtToStsConverter:
        default |     enabled: false
-       default |     version: "0.4.0"
+       default |     version: "0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
-       default |     ldapUrl: "ldap://ldap.skead.no:389"
+       default |     ldapUrl: ""
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/web-spec-default.txt
@@ -80,6 +80,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
@@ -729,11 +729,11 @@
       },
       "version": {
         "source": "default",
-        "value": "0.4.0",
+        "value": "0",
         "sources": [
           {
             "name": "default",
-            "value": "0.4.0"
+            "value": "0"
           }
         ]
       },
@@ -769,11 +769,11 @@
       },
       "ldapUrl": {
         "source": "default",
-        "value": "ldap://ldap.skead.no:389",
+        "value": "",
         "sources": [
           {
             "name": "default",
-            "value": "ldap://ldap.skead.no:389"
+            "value": ""
           }
         ]
       }

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
@@ -737,7 +737,7 @@
           }
         ]
       },
-      "discoveryUrl": {
+      "jwksUrl": {
         "source": "default",
         "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
@@ -757,7 +757,7 @@
           }
         ]
       },
-      "ldapUserSecretRef": {
+      "ldapUserVaultName": {
         "source": "default",
         "value": "",
         "sources": [

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
@@ -739,11 +739,11 @@
       },
       "discoveryUrl": {
         "source": "default",
-        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys",
         "sources": [
           {
             "name": "default",
-            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+            "value": "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
           }
         ]
       },

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
@@ -737,6 +737,16 @@
           }
         ]
       },
+      "discoveryUrl": {
+        "source": "default",
+        "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys",
+        "sources": [
+          {
+            "name": "default",
+            "value": "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+          }
+        ]
+      },
       "ivGroupsRequired": {
         "source": "default",
         "value": false,

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.json
@@ -746,6 +746,26 @@
             "value": false
           }
         ]
+      },
+      "ldapUserSecretRef": {
+        "source": "default",
+        "value": "",
+        "sources": [
+          {
+            "name": "default",
+            "value": ""
+          }
+        ]
+      },
+      "ldapUrl": {
+        "source": "default",
+        "value": "ldap://ldap.skead.no:389",
+        "sources": [
+          {
+            "name": "default",
+            "value": "ldap://ldap.skead.no:389"
+          }
+        ]
       }
     },
     "managedRoute": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
@@ -74,11 +74,11 @@ utv/about.json | cluster: "utv"
                | azure:
                |   jwtToStsConverter:
        default |     enabled: false
-       default |     version: "0.4.0"
+       default |     version: "0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
-       default |     ldapUrl: "ldap://ldap.skead.no:389"
+       default |     ldapUrl: ""
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
@@ -75,7 +75,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
+       default |     jwksUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserVaultName: ""
        default |     ldapUrl: ""

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
@@ -75,7 +75,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
-       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
@@ -77,7 +77,7 @@ utv/about.json | cluster: "utv"
        default |     version: "0.4.0"
        default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.sikker-prod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
-       default |     ldapUserSecretRef: ""
+       default |     ldapUserVaultName: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
@@ -76,6 +76,8 @@ utv/about.json | cluster: "utv"
        default |     enabled: false
        default |     version: "0.4.0"
        default |     ivGroupsRequired: false
+       default |     ldapUserSecretRef: ""
+       default |     ldapUrl: "ldap://ldap.skead.no:389"
        default |   managedRoute: false
                |   apim:
        default |     enabled: false

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/whoami-spec-default.txt
@@ -75,6 +75,7 @@ utv/about.json | cluster: "utv"
                |   jwtToStsConverter:
        default |     enabled: false
        default |     version: "0.4.0"
+       default |     discoveryUrl: "http://login-microsoftonline-com.app2ext.intern-preprod.skead.no/common/discovery/keys"
        default |     ivGroupsRequired: false
        default |     ldapUserSecretRef: ""
        default |     ldapUrl: "ldap://ldap.skead.no:389"

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
@@ -105,7 +105,7 @@
               "initialDelaySeconds": 10,
               "timeoutSeconds": 2
             },
-            "name": "simple-clinger-mix",
+            "name": "simple-clinger-sidecar",
             "ports": [
               {
                 "containerPort": 8100,

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
@@ -1,0 +1,160 @@
+{
+  "apiVersion": "apps.openshift.io/v1",
+  "kind": "DeploymentConfig",
+  "metadata": {
+    "name": "simple",
+    "namespace": "paas-utv"
+  },
+  "spec": {
+    "replicas": 1,
+    "selector": {
+      "name": "simple"
+    },
+    "strategy": {
+      "rollingParams": {
+        "intervalSeconds": 1,
+        "maxSurge": "25%",
+        "maxUnavailable": 0,
+        "timeoutSeconds": 180,
+        "updatePeriodSeconds": 1
+      },
+      "type": "Rolling"
+    },
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "simple"
+          },
+          {
+            "env": [
+              {
+                "name": "CLINGER_PROXY_SERVER_PORT",
+                "value": "8100"
+              },
+              {
+                "name": "CLINGER_MANAGEMENT_SERVER_PORT",
+                "value": "8101"
+              }, {
+                "name": "CLINGER_PROXY_BACKEND_HOST",
+                "value" : "0.0.0.0"
+              }, {
+                "name": "CLINGER_PROXY_BACKEND_PORT",
+                "value" : "8080"
+              }, {
+                "name": "CLINGER_PROXY_SERVER_PORT",
+                "value" : "8100"
+              }, {
+                "name": "CLINGER_AURORAAZUREAPP_NAME",
+                "value" : "simple"
+              }, {
+                "name": "CLINGER_WEBSEAL_TRAFFIC_ACCEPTED",
+                "value" : "false"
+              }, {
+                "name":"POD_NAMESPACE",
+                "valueFrom":{
+                  "fieldRef":{
+                    "apiVersion":"v1",
+                    "fieldPath":"metadata.namespace"
+                  }
+                }
+              }, {
+                "name":"POD_NAME",
+                "valueFrom":{
+                  "fieldRef":{
+                    "apiVersion":"v1",
+                    "fieldPath":"metadata.name"
+                  }
+                }
+              }, {
+                "name": "CLINGER_DISCOVERY_URL",
+                "value" : "https://endpoint"
+              }, {
+                "name": "CLINGER_IV_GROUPS_REQUIRED",
+                "value" : "true"
+              }, {
+                "name":"CLINGER_LDAP_USERNAME",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "key":"ldap.username",
+                    "name":"foo-vault",
+                    "optional":false
+                  }
+                }
+              }, {
+                "name":"CLINGER_LDAP_PASSWORD",
+                "valueFrom": {
+                  "secretKeyRef":{
+                    "key":"ldap.password",
+                    "name":"foo-vault",
+                    "optional":false
+                  }
+                }
+              }, {
+                "name":"CLINGER_LDAP_ADDRESS",
+                "value":"ldap://default"
+              }
+            ],
+            "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/liveness",
+                "port": 8101
+              },
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 2
+            },
+            "name": "simple-clinger-mix",
+            "ports": [
+              {
+                "containerPort": 8100,
+                "name": "http",
+                "protocol": "TCP"
+              },
+              {
+                "containerPort": 8101,
+                "name": "management",
+                "protocol": "TCP"
+              }
+            ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/ready",
+                "port": 8101
+              },
+              "initialDelaySeconds": 10,
+              "timeoutSeconds": 2
+            },
+            "resources": {
+              "limits": {
+                "memory": "256Mi",
+                "cpu": "1"
+              },
+              "requests": {
+                "memory": "128Mi",
+                "cpu": "25m"
+              }
+            }
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "restartPolicy": "Always"
+      }
+    },
+    "triggers": [
+      {
+        "imageChangeParams": {
+          "automatic": true,
+          "containerNames": [
+            "simple"
+          ],
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "simple:default"
+          }
+        },
+        "type": "ImageChange"
+      }
+    ]
+  }
+}

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
@@ -76,8 +76,8 @@
                 "name":"CLINGER_LDAP_USERNAME",
                 "valueFrom": {
                   "secretKeyRef": {
-                    "key":"ldap.username",
-                    "name":"foo-vault",
+                    "key":"azure.ldap.username",
+                    "name":"simple-foo-vault",
                     "optional":false
                   }
                 }
@@ -85,8 +85,8 @@
                 "name":"CLINGER_LDAP_PASSWORD",
                 "valueFrom": {
                   "secretKeyRef":{
-                    "key":"ldap.password",
-                    "name":"foo-vault",
+                    "key":"azure.ldap.password",
+                    "name":"simple-foo-vault",
                     "optional":false
                   }
                 }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
@@ -96,7 +96,6 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
-            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
@@ -70,6 +70,9 @@
                 "name": "CLINGER_DISCOVERY_URL",
                 "value" : "https://endpoint"
               }, {
+                "name": "CLINGER_JWKS_URL",
+                "value" : "https://endpoint"
+              }, {
                 "name": "CLINGER_IV_GROUPS_REQUIRED",
                 "value" : "true"
               }, {

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-ivgroups-true.json
@@ -96,6 +96,7 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
+            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
@@ -70,6 +70,9 @@
                 "name": "CLINGER_DISCOVERY_URL",
                 "value" : "https://endpoint"
               }, {
+                "name": "CLINGER_JWKS_URL",
+                "value" : "https://endpoint"
+              }, {
                 "name": "CLINGER_IV_GROUPS_REQUIRED",
                 "value" : "false"
               }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
@@ -84,7 +84,7 @@
               "initialDelaySeconds": 10,
               "timeoutSeconds": 2
             },
-            "name": "simple-clinger-mix",
+            "name": "simple-clinger-sidecar",
             "ports": [
               {
                 "containerPort": 8100,

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
@@ -75,7 +75,6 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
-            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-webseal-true.json
@@ -75,6 +75,7 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
+            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
@@ -81,7 +81,7 @@
               "initialDelaySeconds": 10,
               "timeoutSeconds": 2
             },
-            "name": "simple-clinger-mix",
+            "name": "simple-clinger-sidecar",
             "ports": [
               {
                 "containerPort": 8100,

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
@@ -72,6 +72,7 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
+            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
@@ -64,6 +64,9 @@
                 "name": "CLINGER_DISCOVERY_URL",
                 "value" : "https://endpoint"
               }, {
+                "name": "CLINGER_JWKS_URL",
+                "value" : "https://endpoint"
+              }, {
                 "name": "CLINGER_WEBSEAL_TRAFFIC_ACCEPTED",
                 "value" : "false"
               }, {

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-with-webseal.json
@@ -72,7 +72,6 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
-            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
@@ -84,7 +84,7 @@
               "initialDelaySeconds": 10,
               "timeoutSeconds": 2
             },
-            "name": "simple-clinger-mix",
+            "name": "simple-clinger-sidecar",
             "ports": [
               {
                 "containerPort": 8100,

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
@@ -70,6 +70,9 @@
                 "name": "CLINGER_DISCOVERY_URL",
                 "value" : "http://jwks"
               }, {
+                "name": "CLINGER_JWKS_URL",
+                "value" : "http://jwks"
+              }, {
                 "name": "CLINGER_IV_GROUPS_REQUIRED",
                 "value" : "false"
               }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
@@ -75,7 +75,6 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
-            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
@@ -75,6 +75,7 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
+            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc-wo-discovery.json
@@ -67,6 +67,9 @@
                   }
                 }
               }, {
+                "name": "CLINGER_DISCOVERY_URL",
+                "value" : "http://jwks"
+              }, {
                 "name": "CLINGER_IV_GROUPS_REQUIRED",
                 "value" : "false"
               }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
@@ -70,6 +70,9 @@
                 "name": "CLINGER_DISCOVERY_URL",
                 "value" : "https://endpoint"
               }, {
+                "name": "CLINGER_JWKS_URL",
+                "value" : "https://endpoint"
+              }, {
                 "name": "CLINGER_IV_GROUPS_REQUIRED",
                 "value" : "false"
               }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
@@ -84,7 +84,7 @@
               "initialDelaySeconds": 10,
               "timeoutSeconds": 2
             },
-            "name": "simple-clinger-mix",
+            "name": "simple-clinger-sidecar",
             "ports": [
               {
                 "containerPort": 8100,

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
@@ -75,7 +75,6 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
-            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/dc.json
@@ -75,6 +75,7 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:1234567",
+            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
@@ -70,6 +70,9 @@
                 "name": "CLINGER_DISCOVERY_URL",
                 "value" : "https://endpoint"
               }, {
+                "name": "CLINGER_JWKS_URL",
+                "value" : "https://endpoint"
+              }, {
                 "name": "CLINGER_IV_GROUPS_REQUIRED",
                 "value" : "false"
               }

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
@@ -84,7 +84,7 @@
               "initialDelaySeconds": 10,
               "timeoutSeconds": 2
             },
-            "name": "simple-clinger-mix",
+            "name": "simple-clinger-sidecar",
             "ports": [
               {
                 "containerPort": 8100,

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
@@ -75,7 +75,6 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:11223344",
-            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/JwtToStsConverterSubPartTest/updated-version-dc.json
@@ -75,6 +75,7 @@
               }
             ],
             "image": "docker.registry/no_skatteetaten_aurora/clinger@sha:11223344",
+            "imagePullPolicy":"Always",
             "livenessProbe": {
               "httpGet": {
                 "path": "/liveness",

--- a/src/test/resources/no/skatteetaten/aurora/boober/unit/OpenShiftCommandServiceTest/iis-failed.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/unit/OpenShiftCommandServiceTest/iis-failed.json
@@ -175,8 +175,8 @@
               },
               {
                 "created": "2018-11-09T07:40:11Z",
-                "dockerImageReference": "docker-registry.aurora.sits.no:5000/no_skatteetaten_aurora_demo/whoami@sha256:ced02f3cdeb1e2726431f3381eceaa64b0b4301e650af409dba766c908cf6606",
-                "image": "sha256:ced02f3cdeb1e2726431f3381eceaa64b0b4301e650af409dba766c908cf6606",
+                "dockerImageReference": "docker-registry.aurora.sits.no:5000/no_skatteetaten_aurora_demo/whoami@sha256:ced02f3cdeb1e2726431f3381eceaa64b01e650af409dba766c908cf6606",
+                "image": "sha256:ced02f3cdeb1e2726431f3381eceaa64b01e650af409dba766c908cf6606",
                 "generation": 17
               },
               {


### PR DESCRIPTION
Denne ble mer voldsom enn planlagt, mest fordi den medfører endring i output både på ao spec og på deploymentconfigen og derfor store mengder med endrede testdata.

Kort oppsummert:
Tjenesten setter nå secret-refs på clinger når alle de nødvendige verdier er satt. I tillegg er det lagt inn støtte for å sette et par konstanter som gjelder på tvers av tjenester som settings på boober.