### PR TITLE
AOS-6622: add validation check if externalHost is set when apiPaths is set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     id("java")
-    id("no.skatteetaten.gradle.aurora") version "4.4.19"
+    id("no.skatteetaten.gradle.aurora") version "4.4.22"
 }
 
 aurora {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/BigIpFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/BigIpFeature.kt
@@ -25,7 +25,8 @@ class BigIpFeature(
     enum class Errors(val message: String) {
         MissingLegacyService("bigip/service is required if other bigip flags are set. bigip/service is deprecated and you should move that configuration to bigip/<name>/service."),
         MissingMultipleService("bigip/<name>/service is required if any other bigip flags are set"),
-        BothLegacyAndMultipleConfigIsSet("specifying both bigip/service and bigip/<name>/service is not allowed. bigip/service is deprecated and you should move that configuration to bigip/<name>/service.")
+        BothLegacyAndMultipleConfigIsSet("specifying both bigip/service and bigip/<name>/service is not allowed. bigip/service is deprecated and you should move that configuration to bigip/<name>/service."),
+        MissingExternalHostWhenApiPathsIsSet("bigip externalHost property is required when bigip apiPaths property is set.")
     }
 
     val bigIpLegacyConfigKeys: List<String> = listOf(
@@ -97,6 +98,22 @@ class BigIpFeature(
 
         if (isMissingMultipleServiceConfig) {
             return listOf(AuroraDeploymentSpecValidationException(Errors.MissingMultipleService.message))
+        }
+
+        val isMissingExternalHostWhenApiPathsIsSet = if (isMultipleConfig) {
+            hosts.any {
+                val hasApiPaths = !adc.getDelimitedStringOrArrayAsSetOrNull("bigip/$it/apiPaths").isNullOrEmpty()
+                val missingExternalHost = adc.getOrNull<String>("bigip/$it/externalHost").isNullOrEmpty()
+                hasApiPaths && missingExternalHost
+            }
+        } else {
+            val hasApiPaths = !adc.getDelimitedStringOrArrayAsSetOrNull("bigip/apiPaths").isNullOrEmpty()
+            val missingExternalHost = adc.getOrNull<String>("bigip/externalHost").isNullOrEmpty()
+            hasApiPaths && missingExternalHost
+        }
+
+        if (isMissingExternalHostWhenApiPathsIsSet) {
+            return listOf(AuroraDeploymentSpecValidationException(Errors.MissingExternalHostWhenApiPathsIsSet.message))
         }
 
         return emptyList()

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/BigIpFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/BigIpFeatureTest.kt
@@ -7,6 +7,7 @@ import io.fabric8.openshift.api.model.Route
 import no.skatteetaten.aurora.boober.model.openshift.BigIp
 import no.skatteetaten.aurora.boober.model.openshift.BigIpSpec
 import no.skatteetaten.aurora.boober.utils.AbstractFeatureTest
+import no.skatteetaten.aurora.boober.utils.singleApplicationError
 import no.skatteetaten.aurora.boober.utils.singleApplicationErrorResult
 import org.junit.jupiter.api.Test
 
@@ -94,6 +95,48 @@ class BigIpFeatureTest : AbstractFeatureTest() {
 
         val bigIpSpec: BigIpSpec = (bigIpResource.resource as BigIp).spec
         assertThat(routeResource.resource.metadata.name).isEqualTo(bigIpSpec.routeName)
+    }
+
+    @Test
+    fun `should fail validation when apiPaths is set but externalHost is not set (multiple services)`() {
+        assertThat {
+            generateResources(
+                """{
+                  "bigip" : {
+                    "simple": {
+                      "enabled": true,
+                      "service" : "simple",
+                      "asmPolicy": "something",
+                      "oauthScopes": "test",
+                      "apiPaths": "/api/simple/,/web/simple/",
+                      "routeAnnotations" : {
+                        "haproxy.router.openshift.io|timeout" : "30s"
+                      }
+                    }
+                  }
+                }"""
+            )
+        }.singleApplicationError(BigIpFeature.Errors.MissingExternalHostWhenApiPathsIsSet.message)
+    }
+
+    @Test
+    fun `should fail validation when apiPaths is set but externalHost is not set (legacy)`() {
+        assertThat {
+            generateResources(
+                """{
+                  "bigip" : {
+                    "enabled": true,
+                    "service" : "simple",
+                    "asmPolicy": "something",
+                    "oauthScopes": "test",
+                    "apiPaths": "/api/simple/,/web/simple/",
+                    "routeAnnotations" : {
+                      "haproxy.router.openshift.io|timeout" : "30s"
+                    }
+                  }
+                }"""
+            )
+        }.singleApplicationError(BigIpFeature.Errors.MissingExternalHostWhenApiPathsIsSet.message)
     }
 
     @Test


### PR DESCRIPTION
lagt til validering på at externalHost er satt når apiPaths er satt.