### PR TITLE
AOS-6986: handle nodeSelector labels with slash

### DIFF
--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeature.kt
@@ -21,7 +21,6 @@ import no.skatteetaten.aurora.boober.utils.addIfNotNull
 import no.skatteetaten.aurora.boober.utils.allNonSideCarContainers
 import no.skatteetaten.aurora.boober.utils.disallowedPattern
 import no.skatteetaten.aurora.boober.utils.boolean
-import no.skatteetaten.aurora.boober.utils.convertValueToString
 import no.skatteetaten.aurora.boober.utils.ensureStartWith
 import no.skatteetaten.aurora.boober.utils.filterNullValues
 import no.skatteetaten.aurora.boober.utils.normalizeLabels
@@ -55,25 +54,19 @@ val AuroraDeploymentSpec.managementPath
         "$port$path"
     }
 
-fun AuroraContextCommand.nodeSelectorHandlers(): Set<AuroraConfigFieldHandler> {
-    val subHandlers = this.applicationFiles
-        .findSubHandlers("nodeSelector")
-        .toSet()
-    return if (subHandlers.isNotEmpty()) {
-        subHandlers.addIfNotNull(AuroraConfigFieldHandler("nodeSelector"))
-    } else {
-        emptySet()
-    }
-}
+fun AuroraContextCommand.nodeSelectorHandlers(): Set<AuroraConfigFieldHandler> = this.applicationFiles
+    .findSubHandlers("nodeSelector", validatorFn = { key ->
+        {
+            if (key.contains("/")) {
+                IllegalArgumentException("NodeSelector key $key cannot contain '/'. Use '|' instead")
+            } else null
+        }
+    })
+    .toSet()
 
-val AuroraDeploymentSpec.nodeSelector: Map<String, String>? get() = this.getOrNull<Map<String, Any?>>("nodeSelector")
-    ?.map { k ->
-        k.value?.let {
-            v ->
-            k.key to convertValueToString(v)
-        } ?: run { k.key to "" }
-    }
-    ?.toMap()
+val AuroraDeploymentSpec.nodeSelector: Map<String, String>? get() = getSubKeysMap("nodeSelector/")
+    .mapKeys { kv -> kv.key.replace("|", "/") }
+    .let { it.ifEmpty { null } }
 
 @Service
 class DeploymentConfigFeature() : Feature {

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeature.kt
@@ -163,7 +163,7 @@ class DeploymentConfigFeature() : Feature {
                 }
 
                 adc.nodeSelector?.let { nodeSelector ->
-                    dc.spec.template.spec.nodeSelector = dc.spec.template.spec.nodeSelector?.addIfNotNull(nodeSelector) ?: nodeSelector
+                    dc.spec.template.spec.nodeSelector = nodeSelector
                 }
             } else if (it.resource.kind == "Deployment") {
                 val deployment: Deployment = it.resource as Deployment

--- a/src/main/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeature.kt
+++ b/src/main/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeature.kt
@@ -15,11 +15,13 @@ import no.skatteetaten.aurora.boober.model.AuroraConfigFieldHandler
 import no.skatteetaten.aurora.boober.model.AuroraContextCommand
 import no.skatteetaten.aurora.boober.model.AuroraDeploymentSpec
 import no.skatteetaten.aurora.boober.model.AuroraResource
+import no.skatteetaten.aurora.boober.model.findSubHandlers
 import no.skatteetaten.aurora.boober.model.openshift.ApplicationDeployment
 import no.skatteetaten.aurora.boober.utils.addIfNotNull
 import no.skatteetaten.aurora.boober.utils.allNonSideCarContainers
 import no.skatteetaten.aurora.boober.utils.disallowedPattern
 import no.skatteetaten.aurora.boober.utils.boolean
+import no.skatteetaten.aurora.boober.utils.convertValueToString
 import no.skatteetaten.aurora.boober.utils.ensureStartWith
 import no.skatteetaten.aurora.boober.utils.filterNullValues
 import no.skatteetaten.aurora.boober.utils.normalizeLabels
@@ -53,20 +55,25 @@ val AuroraDeploymentSpec.managementPath
         "$port$path"
     }
 
-val AuroraDeploymentSpec.nodeSelector: Map<String, String>? get() = this.getOrNull<List<String>>("nodeSelector")
-    ?.let { labelList ->
-        labelList.filter { it.isNotBlank() }
-            .associate { str ->
-                str.split("=", limit = 2).let { strList ->
-                    val label = strList[0].trim()
-                    if (strList.size > 1) {
-                        label to strList[1].trim()
-                    } else {
-                        label to ""
-                    }
-                }
-            }
+fun AuroraContextCommand.nodeSelectorHandlers(): Set<AuroraConfigFieldHandler> {
+    val subHandlers = this.applicationFiles
+        .findSubHandlers("nodeSelector")
+        .toSet()
+    return if (subHandlers.isNotEmpty()) {
+        subHandlers.addIfNotNull(AuroraConfigFieldHandler("nodeSelector"))
+    } else {
+        emptySet()
     }
+}
+
+val AuroraDeploymentSpec.nodeSelector: Map<String, String>? get() = this.getOrNull<Map<String, Any?>>("nodeSelector")
+    ?.map { k ->
+        k.value?.let {
+            v ->
+            k.key to convertValueToString(v)
+        } ?: run { k.key to "" }
+    }
+    ?.toMap()
 
 @Service
 class DeploymentConfigFeature() : Feature {
@@ -121,10 +128,10 @@ class DeploymentConfigFeature() : Feature {
             AuroraConfigFieldHandler("pause", defaultValue = false, validator = { it.boolean() }),
             AuroraConfigFieldHandler("splunkIndex"),
             AuroraConfigFieldHandler("debug", defaultValue = false, validator = { it.boolean() }),
-            AuroraConfigFieldHandler("nodeSelector")
         )
             .addIfNotNull(gavHandlers(header, cmd))
             .addIfNotNull(templateSpecificHeaders)
+            .addIfNotNull(cmd.nodeSelectorHandlers())
     }
 
     override fun modify(

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
@@ -241,7 +241,7 @@ class DeploymentConfigFeatureTest : AbstractFeatureTest() {
                 "version" : "1",
                 "nodeSelector": {
                     "selector1": "test",
-                    "selector2/sub": "test"
+                    "selector2|sub": "test"
                 }
            }""",
             resources = mutableSetOf(createEmptyDeploymentConfig(), createEmptyApplicationDeployment()),

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
@@ -241,7 +241,7 @@ class DeploymentConfigFeatureTest : AbstractFeatureTest() {
                 "version" : "1",
                 "nodeSelector": {
                     "selector1": "test",
-                    "selector2": "test"
+                    "selector2/sub": "test"
                 }
            }""",
             resources = mutableSetOf(createEmptyDeploymentConfig(), createEmptyApplicationDeployment()),

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
@@ -239,10 +239,10 @@ class DeploymentConfigFeatureTest : AbstractFeatureTest() {
             app = """{
                 "groupId": "no.skatteetaten.aurora",
                 "version" : "1",
-                "nodeSelector": [
-                    "selector1=test",
-                    "selector2/sub = test"
-                ]
+                "nodeSelector": {
+                    "selector1": "test",
+                    "selector2/sub": "test"
+                }
            }""",
             resources = mutableSetOf(createEmptyDeploymentConfig(), createEmptyApplicationDeployment()),
             files = listOf(AuroraConfigFile("simple.json", """{ "pause" : true }""", override = true)),

--- a/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
+++ b/src/test/kotlin/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest.kt
@@ -239,10 +239,10 @@ class DeploymentConfigFeatureTest : AbstractFeatureTest() {
             app = """{
                 "groupId": "no.skatteetaten.aurora",
                 "version" : "1",
-                "nodeSelector": {
-                    "selector1": "test",
-                    "selector2/sub": "test"
-                }
+                "nodeSelector": [
+                    "selector1=test",
+                    "selector2/sub = test"
+                ]
            }""",
             resources = mutableSetOf(createEmptyDeploymentConfig(), createEmptyApplicationDeployment()),
             files = listOf(AuroraConfigFile("simple.json", """{ "pause" : true }""", override = true)),

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -712,16 +712,18 @@
     }
   },
   "nodeSelector": {
-    "type": {
-      "source": "complex.json",
-      "value": "test",
-      "sources": [
-        {
-          "name": "complex.json",
-          "value": "test"
+    "source": "complex.json",
+    "value": {
+      "node-role.kubernetes.io/largemem": true
+    },
+    "sources": [
+      {
+        "name": "complex.json",
+        "value": {
+          "node-role.kubernetes.io/largemem": true
         }
-      ]
-    }
+      }
+    ]
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -712,18 +712,16 @@
     }
   },
   "nodeSelector": {
-    "source": "complex.json",
-    "value": {
-      "node-role.kubernetes.io/largemem": true
-    },
-    "sources": [
-      {
-        "name": "complex.json",
-        "value": {
-          "node-role.kubernetes.io/largemem": true
+    "node-role.kubernetes.io|largemem": {
+      "source": "complex.json",
+      "value": true,
+      "sources": [
+        {
+          "name": "complex.json",
+          "value": true
         }
-      }
-    ]
+      ]
+    }
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -629,6 +629,20 @@
       }
     ]
   },
+  "nodeSelector": {
+    "source": "complex.json",
+    "value": [
+      "node-role.kubernetes.io/largemem=true"
+    ],
+    "sources": [
+      {
+        "name": "complex.json",
+        "value": [
+          "node-role.kubernetes.io/largemem=true"
+        ]
+      }
+    ]
+  },
   "artifactId": {
     "source": "fileName",
     "value": "complex",
@@ -710,20 +724,6 @@
         ]
       }
     }
-  },
-  "nodeSelector": {
-    "source": "complex.json",
-    "value": {
-      "node-role.kubernetes.io/largemem": true
-    },
-    "sources": [
-      {
-        "name": "complex.json",
-        "value": {
-          "node-role.kubernetes.io/largemem": true
-        }
-      }
-    ]
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.json
@@ -629,20 +629,6 @@
       }
     ]
   },
-  "nodeSelector": {
-    "source": "complex.json",
-    "value": [
-      "node-role.kubernetes.io/largemem=true"
-    ],
-    "sources": [
-      {
-        "name": "complex.json",
-        "value": [
-          "node-role.kubernetes.io/largemem=true"
-        ]
-      }
-    ]
-  },
   "artifactId": {
     "source": "fileName",
     "value": "complex",
@@ -724,6 +710,20 @@
         ]
       }
     }
+  },
+  "nodeSelector": {
+    "source": "complex.json",
+    "value": {
+      "node-role.kubernetes.io/largemem": true
+    },
+    "sources": [
+      {
+        "name": "complex.json",
+        "value": {
+          "node-role.kubernetes.io/largemem": true
+        }
+      }
+    ]
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -71,7 +71,6 @@ utv/about-alternate.json |   ignoreMissingSchema: true
             complex.json | pause: true
             complex.json | splunkIndex: "test-index"
             complex.json | debug: true
-            complex.json | nodeSelector: ["node-role.kubernetes.io/largemem=true"]
                 fileName | artifactId: "complex"
             complex.json | version: "1"
                          | resources:
@@ -81,6 +80,7 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
+            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
                          | deployStrategy:
             complex.json |   type: "recreate"
                  default |   timeout: 180

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -80,7 +80,8 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
-            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
+                         | nodeSelector:
+            complex.json |   node-role.kubernetes.io|largemem: true
                          | deployStrategy:
             complex.json |   type: "recreate"
                  default |   timeout: 180

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -80,8 +80,7 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
-                         | nodeSelector:
-            complex.json |   type: "test"
+            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
                          | deployStrategy:
             complex.json |   type: "recreate"
                  default |   timeout: 180

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec-default.txt
@@ -71,6 +71,7 @@ utv/about-alternate.json |   ignoreMissingSchema: true
             complex.json | pause: true
             complex.json | splunkIndex: "test-index"
             complex.json | debug: true
+            complex.json | nodeSelector: ["node-role.kubernetes.io/largemem=true"]
                 fileName | artifactId: "complex"
             complex.json | version: "1"
                          | resources:
@@ -80,7 +81,6 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
-            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
                          | deployStrategy:
             complex.json |   type: "recreate"
                  default |   timeout: 180

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
@@ -537,6 +537,20 @@
       }
     ]
   },
+  "nodeSelector": {
+    "source": "complex.json",
+    "value": [
+      "node-role.kubernetes.io/largemem=true"
+    ],
+    "sources": [
+      {
+        "name": "complex.json",
+        "value": [
+          "node-role.kubernetes.io/largemem=true"
+        ]
+      }
+    ]
+  },
   "artifactId": {
     "source": "fileName",
     "value": "complex",
@@ -618,20 +632,6 @@
         ]
       }
     }
-  },
-  "nodeSelector": {
-    "source": "complex.json",
-    "value": {
-      "node-role.kubernetes.io/largemem": true
-    },
-    "sources": [
-      {
-        "name": "complex.json",
-        "value": {
-          "node-role.kubernetes.io/largemem": true
-        }
-      }
-    ]
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
@@ -620,18 +620,16 @@
     }
   },
   "nodeSelector": {
-    "source": "complex.json",
-    "value": {
-      "node-role.kubernetes.io/largemem": true
-    },
-    "sources": [
-      {
-        "name": "complex.json",
-        "value": {
-          "node-role.kubernetes.io/largemem": true
+    "node-role.kubernetes.io|largemem": {
+      "source": "complex.json",
+      "value": true,
+      "sources": [
+        {
+          "name": "complex.json",
+          "value": true
         }
-      }
-    ]
+      ]
+    }
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
@@ -537,20 +537,6 @@
       }
     ]
   },
-  "nodeSelector": {
-    "source": "complex.json",
-    "value": [
-      "node-role.kubernetes.io/largemem=true"
-    ],
-    "sources": [
-      {
-        "name": "complex.json",
-        "value": [
-          "node-role.kubernetes.io/largemem=true"
-        ]
-      }
-    ]
-  },
   "artifactId": {
     "source": "fileName",
     "value": "complex",
@@ -632,6 +618,20 @@
         ]
       }
     }
+  },
+  "nodeSelector": {
+    "source": "complex.json",
+    "value": {
+      "node-role.kubernetes.io/largemem": true
+    },
+    "sources": [
+      {
+        "name": "complex.json",
+        "value": {
+          "node-role.kubernetes.io/largemem": true
+        }
+      }
+    ]
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.json
@@ -620,16 +620,18 @@
     }
   },
   "nodeSelector": {
-    "type": {
-      "source": "complex.json",
-      "value": "test",
-      "sources": [
-        {
-          "name": "complex.json",
-          "value": "test"
+    "source": "complex.json",
+    "value": {
+      "node-role.kubernetes.io/largemem": true
+    },
+    "sources": [
+      {
+        "name": "complex.json",
+        "value": {
+          "node-role.kubernetes.io/largemem": true
         }
-      ]
-    }
+      }
+    ]
   },
   "deployStrategy": {
     "type": {

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
@@ -70,8 +70,7 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
-                         | nodeSelector:
-            complex.json |   type: "test"
+            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
                          | deployStrategy:
             complex.json |   type: "recreate"
             complex.json | serviceAccount: "aurora-fraggle"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
@@ -70,7 +70,8 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
-            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
+                         | nodeSelector:
+            complex.json |   node-role.kubernetes.io|largemem: true
                          | deployStrategy:
             complex.json |   type: "recreate"
             complex.json | serviceAccount: "aurora-fraggle"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
@@ -61,6 +61,7 @@ utv/about-alternate.json |   ignoreMissingSchema: true
             complex.json | pause: true
             complex.json | splunkIndex: "test-index"
             complex.json | debug: true
+            complex.json | nodeSelector: ["node-role.kubernetes.io/largemem=true"]
                 fileName | artifactId: "complex"
             complex.json | version: "1"
                          | resources:
@@ -70,7 +71,6 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
-            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
                          | deployStrategy:
             complex.json |   type: "recreate"
             complex.json | serviceAccount: "aurora-fraggle"

--- a/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
+++ b/src/test/resources/no/skatteetaten/aurora/boober/facade/DeployFacadeTest/complex-spec.txt
@@ -61,7 +61,6 @@ utv/about-alternate.json |   ignoreMissingSchema: true
             complex.json | pause: true
             complex.json | splunkIndex: "test-index"
             complex.json | debug: true
-            complex.json | nodeSelector: ["node-role.kubernetes.io/largemem=true"]
                 fileName | artifactId: "complex"
             complex.json | version: "1"
                          | resources:
@@ -71,6 +70,7 @@ utv/about-alternate.json |   ignoreMissingSchema: true
                          |   memory:
             complex.json |     min: "64Mi"
             complex.json |     max: "128Mi"
+            complex.json | nodeSelector: {"node-role.kubernetes.io/largemem":true}
                          | deployStrategy:
             complex.json |   type: "recreate"
             complex.json | serviceAccount: "aurora-fraggle"

--- a/src/test/resources/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest/changed-dc-nodeselector.json
+++ b/src/test/resources/no/skatteetaten/aurora/boober/feature/DeploymentConfigFeatureTest/changed-dc-nodeselector.json
@@ -69,7 +69,7 @@
         "dnsPolicy": "ClusterFirst",
         "nodeSelector": {
           "selector1": "test",
-          "selector2": "test"
+          "selector2/sub": "test"
         },
         "restartPolicy": "Always",
         "topologySpreadConstraints": [

--- a/src/test/resources/samples/config/complex.json
+++ b/src/test/resources/samples/config/complex.json
@@ -15,9 +15,9 @@
     "port": "8081",
     "path": "/foobar"
   },
-  "nodeSelector": {
-    "node-role.kubernetes.io/largemem": true
-  },
+  "nodeSelector": [
+    "node-role.kubernetes.io/largemem=true"
+  ],
   "serviceAccount": "aurora-fraggle",
   "mounts": {
     "aurora-token": {

--- a/src/test/resources/samples/config/complex.json
+++ b/src/test/resources/samples/config/complex.json
@@ -16,7 +16,7 @@
     "path": "/foobar"
   },
   "nodeSelector": {
-    "node-role.kubernetes.io/largemem": true
+    "node-role.kubernetes.io|largemem": true
   },
   "serviceAccount": "aurora-fraggle",
   "mounts": {

--- a/src/test/resources/samples/config/complex.json
+++ b/src/test/resources/samples/config/complex.json
@@ -16,7 +16,7 @@
     "path": "/foobar"
   },
   "nodeSelector": {
-    "type": "test"
+    "node-role.kubernetes.io/largemem": true
   },
   "serviceAccount": "aurora-fraggle",
   "mounts": {

--- a/src/test/resources/samples/config/complex.json
+++ b/src/test/resources/samples/config/complex.json
@@ -15,9 +15,9 @@
     "port": "8081",
     "path": "/foobar"
   },
-  "nodeSelector": [
-    "node-role.kubernetes.io/largemem=true"
-  ],
+  "nodeSelector": {
+    "node-role.kubernetes.io/largemem": true
+  },
   "serviceAccount": "aurora-fraggle",
   "mounts": {
     "aurora-token": {

--- a/src/test/resources/samples/result/utv/complex/deploymentconfig.json
+++ b/src/test/resources/samples/result/utv/complex/deploymentconfig.json
@@ -583,7 +583,7 @@
         ],
         "dnsPolicy": "ClusterFirst",
         "nodeSelector": {
-          "type": "test"
+          "node-role.kubernetes.io/largemem": "true"
         },
         "restartPolicy": "Always",
         "serviceAccount": "aurora-fraggle",


### PR DESCRIPTION
Endret litt på implementasjon for å støtte nodeSelector labels med slash.
Oppsummert så legges det til en handler på "nodeSelector" root, subHandlers som opprettes er kun for å få igjennom feltvalidering.

Jeg ønsker forslag om det er en bedre måte å få igjennom feltvalidering, siden dette har litt konsekvenser for spec output.